### PR TITLE
패키징 런타임 의존성 누락 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "electron-dl": "^4.0.0",
     "jszip": "^3.10.1",
     "limiter": "^2.1.0",
+    "lodash": "^4.17.23",
     "lru-cache": "^11.0.2",
     "openai": "latest",
     "prisma": "^6.19.0",
@@ -190,7 +191,8 @@
     "semver": "^7.6.3",
     "sharp": "^0.34.3",
     "uuid": "^11.1.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "winston-transport": "^4.9.0"
   },
   "volta": {
     "node": "22.14.0",

--- a/scripts/prepare-package-optimized.mjs
+++ b/scripts/prepare-package-optimized.mjs
@@ -28,31 +28,63 @@ async function ensureExists(targetPath, errorMessage) {
   }
 }
 
+function toRuntimeDependencies(packageJson) {
+  return Object.entries(packageJson?.dependencies ?? {})
+    .filter(([name]) => !name.startsWith('@apps/'))
+    .reduce((acc, [name, version]) => {
+      acc[name] = version;
+      return acc;
+    }, {});
+}
+
+function sortDependencyMap(dependencies) {
+  return Object.fromEntries(Object.entries(dependencies).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+async function collectWorkspaceRuntimeDependencies(dependencies) {
+  const workspaceDeps = Object.keys(dependencies ?? {}).filter((name) => name.startsWith('@apps/'));
+  if (workspaceDeps.length === 0) {
+    return {};
+  }
+
+  const runtimeDeps = {};
+  for (const workspaceDep of workspaceDeps) {
+    const workspaceName = workspaceDep.replace('@apps/', '');
+    const workspacePackagePath = path.join(repoRoot, 'apps', workspaceName, 'package.json');
+    try {
+      const workspacePackage = JSON.parse(await fs.readFile(workspacePackagePath, 'utf-8'));
+      Object.assign(runtimeDeps, toRuntimeDependencies(workspacePackage));
+    } catch (error) {
+      console.warn(`워크스페이스 의존성 수집 실패: ${workspaceDep} (${error.message ?? error})`);
+    }
+  }
+
+  return runtimeDeps;
+}
+
 /**
  * Automatically sync runtime dependencies from backend to root package.json
  * This eliminates manual dependency duplication
  */
 async function syncRootDependencies(backendPackage) {
   const rootPackage = JSON.parse(await fs.readFile(rootPackagePath, 'utf-8'));
-  const backendDeps = backendPackage.dependencies ?? {};
-  
-  // Filter out workspace dependencies
-  const runtimeDeps = Object.entries(backendDeps)
-    .filter(([name]) => !name.startsWith('@apps/'))
-    .reduce((acc, [name, version]) => {
-      acc[name] = version;
-      return acc;
-    }, {});
-  
+
+  const backendRuntimeDeps = toRuntimeDependencies(backendPackage);
+  const workspaceRuntimeDeps = await collectWorkspaceRuntimeDependencies(backendPackage.dependencies);
+  const runtimeDeps = sortDependencyMap({
+    ...backendRuntimeDeps,
+    ...workspaceRuntimeDeps,
+  });
+
   // Check if root dependencies need update
-  const currentRootDeps = rootPackage.dependencies ?? {};
+  const currentRootDeps = sortDependencyMap(rootPackage.dependencies ?? {});
   const needsUpdate = JSON.stringify(currentRootDeps) !== JSON.stringify(runtimeDeps);
-  
+
   if (needsUpdate) {
     console.log('루트 package.json dependencies 자동 동기화 중...');
     rootPackage.dependencies = runtimeDeps;
     await fs.writeFile(rootPackagePath, JSON.stringify(rootPackage, null, 2) + '\n');
-    
+
     // Trigger yarn install to sync lockfile
     console.log('yarn install 실행 중...');
     try {
@@ -61,7 +93,7 @@ async function syncRootDependencies(backendPackage) {
       console.warn('yarn install 경고:', error.message);
     }
   }
-  
+
   return rootPackage;
 }
 
@@ -184,9 +216,19 @@ async function prepare() {
   const commonPackage = JSON.parse(
     await fs.readFile(path.join(repoRoot, 'apps', 'common', 'package.json'), 'utf-8')
   );
+  const commonRuntimeDeps = sortDependencyMap(toRuntimeDependencies(commonPackage));
   await fs.writeFile(
     path.join(commonInStaging, 'package.json'),
-    JSON.stringify({ name: commonPackage.name, version: commonPackage.version, main: 'dist/index.js' }, null, 2)
+    JSON.stringify(
+      {
+        name: commonPackage.name,
+        version: commonPackage.version,
+        main: 'dist/index.js',
+        dependencies: commonRuntimeDeps,
+      },
+      null,
+      2
+    )
   );
 
   // Fix Prisma location

--- a/scripts/prepare-package-optimized.mjs
+++ b/scripts/prepare-package-optimized.mjs
@@ -72,9 +72,18 @@ async function syncRootDependencies(backendPackage) {
   const backendRuntimeDeps = toRuntimeDependencies(backendPackage);
   const workspaceRuntimeDeps = await collectWorkspaceRuntimeDependencies(backendPackage.dependencies);
   const runtimeDeps = sortDependencyMap({
-    ...backendRuntimeDeps,
     ...workspaceRuntimeDeps,
+    ...backendRuntimeDeps,
   });
+
+  const versionConflicts = Object.entries(workspaceRuntimeDeps).filter(
+    ([name, workspaceVersion]) =>
+      backendRuntimeDeps[name] && backendRuntimeDeps[name] !== workspaceVersion
+  );
+  if (versionConflicts.length > 0) {
+    const conflictNames = versionConflicts.map(([name]) => name).join(', ');
+    console.log(`백엔드 의존성 버전을 우선 적용합니다: ${conflictNames}`);
+  }
 
   // Check if root dependencies need update
   const currentRootDeps = sortDependencyMap(rootPackage.dependencies ?? {});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6878,6 +6878,7 @@ __metadata:
     husky: "npm:^9.1.7"
     jszip: "npm:^3.10.1"
     limiter: "npm:^2.1.0"
+    lodash: "npm:^4.17.23"
     lru-cache: "npm:^11.0.2"
     nodemon: "npm:^3.1.0"
     openai: "npm:latest"
@@ -6896,6 +6897,7 @@ __metadata:
     typescript: "npm:^5.8.2"
     uuid: "npm:^11.1.0"
     winston: "npm:^3.17.0"
+    winston-transport: "npm:^4.9.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## 요약
- 패키징 산출물에서 `lodash`가 누락되어 실행 시 `Cannot find module 'lodash'`가 발생하는 문제를 수정했습니다.
- `prepare-package-optimized` 스크립트가 workspace(`@apps/*`) 의존성의 런타임 패키지를 루트 동기화에 포함하도록 보강했습니다.
- 패키징 시 생성하는 `node_modules/@apps/common/package.json`에 runtime `dependencies`를 포함하도록 수정했습니다.

## 상세 변경
- `scripts/prepare-package-optimized.mjs`
  - backend 의존성 + backend가 참조하는 workspace 의존성의 runtime 패키지를 함께 수집/동기화
  - 의존성 맵 정렬 로직을 추가해 비교/동기화 안정성 개선
  - staging의 `@apps/common/package.json`에 runtime `dependencies` 기록
- `package.json`
  - 루트 런타임 의존성에 `lodash`, `winston-transport` 추가
- `yarn.lock`
  - 위 의존성 추가에 따른 lock 반영

## 검증
- `yarn build` 통과
- `yarn lint` 통과
- `yarn package:prepare` 실행 후 `apps/backend/app/node_modules/@apps/common/package.json`에 `lodash` 포함 확인
- `yarn package:linux` 산출물의 `app.asar`에 `/node_modules/lodash/*` 포함 확인
