### PR TITLE
캐시 히트 결과를 예제 문맥 슬라이딩 윈도우에 반영

### DIFF
--- a/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
+++ b/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
@@ -188,7 +188,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
     const sourceText = 'A\nB';
     const cachedTranslation = 'A\r\nB';
     const translatedText = 'A\nB-tr';
-    const { service, cacheManagerService, tokenService } = createService();
+    const { service, cacheManagerService, tokenService, exampleManagerService } = createService();
 
     cacheManagerService.getTranslations.mockResolvedValue(
       new Map<string, string | null>([[sourceText, cachedTranslation]])
@@ -234,6 +234,14 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
         strictFailureCount: 0,
       },
     ]);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledTimes(1);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledWith(
+      'req-cache-mismatch',
+      SourceLanguage.ENGLISH,
+      TargetLanguage.KOREAN,
+      [sourceText],
+      [translatedText]
+    );
   });
 
   it('캐시 플레이스홀더 보존 불일치가 있으면 재번역한다', async () => {
@@ -320,7 +328,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
   it('캐시 플레이스홀더 규칙이 비활성화면 캐시를 재사용한다', async () => {
     const sourceText = 'Hello {1}\nWorld';
     const cachedTranslation = '안녕\n세계'; // {1} 누락
-    const { service, cacheManagerService, tokenService } = createService();
+    const { service, cacheManagerService, tokenService, exampleManagerService } = createService();
 
     cacheManagerService.getTranslations.mockResolvedValue(
       new Map<string, string | null>([[sourceText, cachedTranslation]])
@@ -372,13 +380,21 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
         strictFailureCount: 0,
       },
     ]);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledTimes(1);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledWith(
+      'req-cache-placeholder-disabled',
+      SourceLanguage.ENGLISH,
+      TargetLanguage.KOREAN,
+      [sourceText],
+      [cachedTranslation]
+    );
   });
 
   it('캐시 플레이스홀더 매칭 문자열이 바뀌면 재번역한다', async () => {
     const sourceText = 'Hello {A} love {B}';
     const cachedTranslation = '{A} love {C}'; // {B} -> {C}
     const translatedText = '{A} love {B}';
-    const { service, cacheManagerService, tokenService } = createService();
+    const { service, cacheManagerService, tokenService, exampleManagerService } = createService();
 
     cacheManagerService.getTranslations.mockResolvedValue(
       new Map<string, string | null>([[sourceText, cachedTranslation]])
@@ -437,5 +453,132 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
         strictFailureCount: 0,
       },
     ]);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledTimes(1);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledWith(
+      'req-cache-placeholder-value-mismatch',
+      SourceLanguage.ENGLISH,
+      TargetLanguage.KOREAN,
+      [sourceText],
+      [translatedText]
+    );
+  });
+
+  it('검증을 통과한 캐시 히트는 배치보다 앞선 순서대로 example manager에 먼저 누적한다', async () => {
+    const cachedSource = 'a';
+    const cachedTranslation = 'A';
+    const uncachedSource = 'b';
+    const uncachedTranslation = 'B';
+    const { service, cacheManagerService, tokenService, exampleManagerService } = createService();
+
+    cacheManagerService.getTranslations.mockResolvedValue(
+      new Map<string, string | null>([
+        [cachedSource, cachedTranslation],
+        [uncachedSource, null],
+      ])
+    );
+    tokenService.getBatchGroups.mockResolvedValue([[uncachedSource]]);
+
+    const translateUncachedTexts = jest.fn().mockResolvedValue({
+      batchTranslations: new Map<string, TranslationResult>([
+        [uncachedSource, { text: uncachedTranslation, indices: [1] }],
+      ]),
+      response: buildResponse(),
+      shouldReduceBatchSize: false,
+      hasPartialData: false,
+      validationMismatchTexts: new Set<string>(),
+    });
+    (
+      service as unknown as {
+        translateUncachedTexts: typeof translateUncachedTexts;
+      }
+    ).translateUncachedTexts = translateUncachedTexts;
+
+    const result = await service.translateText({
+      requestId: 'req-cache-hit-before-batch',
+      sourceTexts: [cachedSource, uncachedSource],
+      promptPresetContent: '',
+      aiSettings: buildAiSettings(),
+      cacheTag: 'default',
+    });
+
+    expect(result.texts).toEqual([cachedTranslation, uncachedTranslation]);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledTimes(2);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenNthCalledWith(
+      1,
+      'req-cache-hit-before-batch',
+      SourceLanguage.ENGLISH,
+      TargetLanguage.KOREAN,
+      [cachedSource],
+      [cachedTranslation]
+    );
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenNthCalledWith(
+      2,
+      'req-cache-hit-before-batch',
+      SourceLanguage.ENGLISH,
+      TargetLanguage.KOREAN,
+      [uncachedSource],
+      [uncachedTranslation]
+    );
+    expect(exampleManagerService.appendCurrentExample.mock.invocationCallOrder[0]).toBeLessThan(
+      translateUncachedTexts.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('뒤쪽 캐시 히트도 입력 순서대로 example manager에 누적한다', async () => {
+    const uncachedSource = 'b';
+    const uncachedTranslation = 'B';
+    const trailingCachedSource = 'c';
+    const trailingCachedTranslation = 'C';
+    const { service, cacheManagerService, tokenService, exampleManagerService } = createService();
+
+    cacheManagerService.getTranslations.mockResolvedValue(
+      new Map<string, string | null>([
+        [uncachedSource, null],
+        [trailingCachedSource, trailingCachedTranslation],
+      ])
+    );
+    tokenService.getBatchGroups.mockResolvedValue([[uncachedSource]]);
+
+    const translateUncachedTexts = jest.fn().mockResolvedValue({
+      batchTranslations: new Map<string, TranslationResult>([
+        [uncachedSource, { text: uncachedTranslation, indices: [0] }],
+      ]),
+      response: buildResponse(),
+      shouldReduceBatchSize: false,
+      hasPartialData: false,
+      validationMismatchTexts: new Set<string>(),
+    });
+    (
+      service as unknown as {
+        translateUncachedTexts: typeof translateUncachedTexts;
+      }
+    ).translateUncachedTexts = translateUncachedTexts;
+
+    const result = await service.translateText({
+      requestId: 'req-trailing-cache-hit',
+      sourceTexts: [uncachedSource, trailingCachedSource],
+      promptPresetContent: '',
+      aiSettings: buildAiSettings(),
+      cacheTag: 'default',
+    });
+
+    expect(result.texts).toEqual([uncachedTranslation, trailingCachedTranslation]);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledTimes(2);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenNthCalledWith(
+      1,
+      'req-trailing-cache-hit',
+      SourceLanguage.ENGLISH,
+      TargetLanguage.KOREAN,
+      [uncachedSource],
+      [uncachedTranslation]
+    );
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenNthCalledWith(
+      2,
+      'req-trailing-cache-hit',
+      SourceLanguage.ENGLISH,
+      TargetLanguage.KOREAN,
+      [trailingCachedSource],
+      [trailingCachedTranslation]
+    );
   });
 });

--- a/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
+++ b/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
@@ -563,22 +563,71 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
     });
 
     expect(result.texts).toEqual([uncachedTranslation, trailingCachedTranslation]);
-    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledTimes(2);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledTimes(1);
     expect(exampleManagerService.appendCurrentExample).toHaveBeenNthCalledWith(
       1,
       'req-trailing-cache-hit',
       SourceLanguage.ENGLISH,
       TargetLanguage.KOREAN,
-      [uncachedSource],
-      [uncachedTranslation]
+      [uncachedSource, trailingCachedSource],
+      [uncachedTranslation, trailingCachedTranslation]
     );
-    expect(exampleManagerService.appendCurrentExample).toHaveBeenNthCalledWith(
-      2,
-      'req-trailing-cache-hit',
+  });
+
+  it('같은 배치 안의 캐시 히트와 신규 번역도 입력 순서대로 example manager에 누적한다', async () => {
+    const firstUncachedSource = 'a';
+    const firstUncachedTranslation = 'A';
+    const cachedSource = 'b';
+    const cachedTranslation = 'B';
+    const secondUncachedSource = 'c';
+    const secondUncachedTranslation = 'C';
+    const { service, cacheManagerService, tokenService, exampleManagerService } = createService();
+
+    cacheManagerService.getTranslations.mockResolvedValue(
+      new Map<string, string | null>([
+        [firstUncachedSource, null],
+        [cachedSource, cachedTranslation],
+        [secondUncachedSource, null],
+      ])
+    );
+    tokenService.getBatchGroups.mockResolvedValue([[firstUncachedSource, secondUncachedSource]]);
+
+    const translateUncachedTexts = jest.fn().mockResolvedValue({
+      batchTranslations: new Map<string, TranslationResult>([
+        [firstUncachedSource, { text: firstUncachedTranslation, indices: [0] }],
+        [secondUncachedSource, { text: secondUncachedTranslation, indices: [2] }],
+      ]),
+      response: buildResponse(),
+      shouldReduceBatchSize: false,
+      hasPartialData: false,
+      validationMismatchTexts: new Set<string>(),
+    });
+    (
+      service as unknown as {
+        translateUncachedTexts: typeof translateUncachedTexts;
+      }
+    ).translateUncachedTexts = translateUncachedTexts;
+
+    const result = await service.translateText({
+      requestId: 'req-interleaved-cache-hit',
+      sourceTexts: [firstUncachedSource, cachedSource, secondUncachedSource],
+      promptPresetContent: '',
+      aiSettings: buildAiSettings(),
+      cacheTag: 'default',
+    });
+
+    expect(result.texts).toEqual([
+      firstUncachedTranslation,
+      cachedTranslation,
+      secondUncachedTranslation,
+    ]);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledTimes(1);
+    expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledWith(
+      'req-interleaved-cache-hit',
       SourceLanguage.ENGLISH,
       TargetLanguage.KOREAN,
-      [trailingCachedSource],
-      [trailingCachedTranslation]
+      [firstUncachedSource, cachedSource, secondUncachedSource],
+      [firstUncachedTranslation, cachedTranslation, secondUncachedTranslation]
     );
   });
 });

--- a/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
+++ b/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
@@ -570,7 +570,11 @@ export class TextBatchTranslationService {
   }> {
     const texts = new Array<string>(sourceTexts.length);
     const remainingTexts = new Map<string, number[]>();
-    const cacheHitExamples: Array<{ index: number; sourceText: string; translatedText: string }> = [];
+    const cacheHitExamples: Array<{
+      index: number;
+      sourceText: string;
+      translatedText: string;
+    }> = [];
     const cachedResults = await this.cacheManagerService.getTranslations(sourceTexts, cacheTag);
 
     sourceTexts.forEach((text, index) => {
@@ -638,10 +642,7 @@ export class TextBatchTranslationService {
 
     while (nextCursor < cacheHitExamples.length) {
       const cacheHit = cacheHitExamples[nextCursor];
-      if (
-        beforeIndexExclusive !== undefined &&
-        cacheHit.index >= beforeIndexExclusive
-      ) {
+      if (beforeIndexExclusive !== undefined && cacheHit.index >= beforeIndexExclusive) {
         break;
       }
 

--- a/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
+++ b/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
@@ -76,13 +76,21 @@ export class TextBatchTranslationService {
     const totalTexts = sourceTexts.length;
 
     try {
-      const { texts, remainingTexts } = await this.applyTranslationCache(
+      const { texts, remainingTexts, cacheHitExamples } = await this.applyTranslationCache(
         sourceTexts,
         normalizedCacheTag,
         placeholderPreservation
       );
+      let cacheHitExampleCursor = 0;
 
       if (remainingTexts.size === 0) {
+        cacheHitExampleCursor = this.appendCacheHitExamples({
+          requestId: param.requestId,
+          sourceLanguage,
+          targetLanguage,
+          cacheHitExamples,
+          cursor: cacheHitExampleCursor,
+        });
         onProgress?.({ completed: totalTexts, total: totalTexts });
         return {
           texts,
@@ -118,6 +126,15 @@ export class TextBatchTranslationService {
           let shouldRestartBatching = false;
 
           try {
+            cacheHitExampleCursor = this.appendCacheHitExamples({
+              requestId: param.requestId,
+              sourceLanguage,
+              targetLanguage,
+              cacheHitExamples,
+              cursor: cacheHitExampleCursor,
+              beforeIndexExclusive: this.getFirstIndexForBatch(batchTexts, currentRemainingTexts),
+            });
+
             for (const text of batchTexts) {
               const indices = currentRemainingTexts.get(text) || [];
               if (indices.length === 0) continue;
@@ -321,6 +338,14 @@ export class TextBatchTranslationService {
         });
         newTranslations.set(originalText, { text: originalText, indices });
       }
+
+      this.appendCacheHitExamples({
+        requestId: param.requestId,
+        sourceLanguage,
+        targetLanguage,
+        cacheHitExamples,
+        cursor: cacheHitExampleCursor,
+      });
 
       if (strictFailureReasonsByText.size > 0) {
         this.logger.warn('엄격 검증 실패를 포함해 번역을 종료합니다.', {
@@ -541,9 +566,11 @@ export class TextBatchTranslationService {
   ): Promise<{
     texts: string[];
     remainingTexts: Map<string, number[]>;
+    cacheHitExamples: Array<{ index: number; sourceText: string; translatedText: string }>;
   }> {
     const texts = new Array<string>(sourceTexts.length);
     const remainingTexts = new Map<string, number[]>();
+    const cacheHitExamples: Array<{ index: number; sourceText: string; translatedText: string }> = [];
     const cachedResults = await this.cacheManagerService.getTranslations(sourceTexts, cacheTag);
 
     sourceTexts.forEach((text, index) => {
@@ -555,6 +582,13 @@ export class TextBatchTranslationService {
 
       if (isCacheHit) {
         texts[index] = translatedText;
+        if (text.trim() !== '') {
+          cacheHitExamples.push({
+            index,
+            sourceText: text,
+            translatedText,
+          });
+        }
       } else {
         const indices = remainingTexts.get(text) || [];
         indices.push(index);
@@ -562,7 +596,71 @@ export class TextBatchTranslationService {
       }
     });
 
-    return { texts, remainingTexts };
+    return { texts, remainingTexts, cacheHitExamples };
+  }
+
+  private getFirstIndexForBatch(
+    batchTexts: string[],
+    remainingTexts: Map<string, number[]>
+  ): number | undefined {
+    let firstIndex: number | undefined;
+
+    for (const text of batchTexts) {
+      const indices = remainingTexts.get(text) || [];
+      for (const index of indices) {
+        if (firstIndex === undefined || index < firstIndex) {
+          firstIndex = index;
+        }
+      }
+    }
+
+    return firstIndex;
+  }
+
+  private appendCacheHitExamples({
+    requestId,
+    sourceLanguage,
+    targetLanguage,
+    cacheHitExamples,
+    cursor,
+    beforeIndexExclusive,
+  }: {
+    requestId: string;
+    sourceLanguage: SourceLanguage;
+    targetLanguage: TargetLanguage;
+    cacheHitExamples: Array<{ index: number; sourceText: string; translatedText: string }>;
+    cursor: number;
+    beforeIndexExclusive?: number;
+  }): number {
+    const sources: string[] = [];
+    const results: string[] = [];
+    let nextCursor = cursor;
+
+    while (nextCursor < cacheHitExamples.length) {
+      const cacheHit = cacheHitExamples[nextCursor];
+      if (
+        beforeIndexExclusive !== undefined &&
+        cacheHit.index >= beforeIndexExclusive
+      ) {
+        break;
+      }
+
+      sources.push(cacheHit.sourceText);
+      results.push(cacheHit.translatedText);
+      nextCursor++;
+    }
+
+    if (sources.length > 0) {
+      this.exampleManagerService.appendCurrentExample(
+        requestId,
+        sourceLanguage,
+        targetLanguage,
+        sources,
+        results
+      );
+    }
+
+    return nextCursor;
   }
 
   private getTranslationFromCachedResult(

--- a/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
+++ b/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
@@ -30,6 +30,7 @@ import { containsLegacyTranslatedTextKey } from '@/nest/translation/prompt/utils
 export class TextBatchTranslationService {
   private readonly MAX_ATTEMPT_COUNT = 3;
   private readonly STABLE_BATCH_RECOVERY_THRESHOLD = 2;
+  private readonly MAX_EXAMPLE_APPEND_CHAR_COUNT = 2000;
 
   constructor(
     @Inject(ICacheManagerService)
@@ -76,21 +77,25 @@ export class TextBatchTranslationService {
     const totalTexts = sourceTexts.length;
 
     try {
-      const { texts, remainingTexts, cacheHitExamples } = await this.applyTranslationCache(
+      const { texts, remainingTexts } = await this.applyTranslationCache(
         sourceTexts,
         normalizedCacheTag,
         placeholderPreservation
       );
-      let cacheHitExampleCursor = 0;
+      const pendingIndices = this.collectPendingIndices(remainingTexts);
+      const appendableIndices = this.collectAppendableIndices(sourceTexts, pendingIndices);
+      let exampleCursor = this.appendResolvedExamples({
+        requestId: param.requestId,
+        sourceTexts,
+        translations: texts,
+        sourceLanguage,
+        targetLanguage,
+        appendableIndices,
+        pendingIndices,
+        cursor: 0,
+      });
 
       if (remainingTexts.size === 0) {
-        cacheHitExampleCursor = this.appendCacheHitExamples({
-          requestId: param.requestId,
-          sourceLanguage,
-          targetLanguage,
-          cacheHitExamples,
-          cursor: cacheHitExampleCursor,
-        });
         onProgress?.({ completed: totalTexts, total: totalTexts });
         return {
           texts,
@@ -126,15 +131,6 @@ export class TextBatchTranslationService {
           let shouldRestartBatching = false;
 
           try {
-            cacheHitExampleCursor = this.appendCacheHitExamples({
-              requestId: param.requestId,
-              sourceLanguage,
-              targetLanguage,
-              cacheHitExamples,
-              cursor: cacheHitExampleCursor,
-              beforeIndexExclusive: this.getFirstIndexForBatch(batchTexts, currentRemainingTexts),
-            });
-
             for (const text of batchTexts) {
               const indices = currentRemainingTexts.get(text) || [];
               if (indices.length === 0) continue;
@@ -175,6 +171,7 @@ export class TextBatchTranslationService {
                   indices.forEach((index) => {
                     intermediateTexts[index] = text;
                   });
+                  this.removePendingIndices(pendingIndices, indices);
                   batchRemainingTexts.delete(text);
                   currentRemainingTexts.delete(text);
                   validationMismatchCounts.delete(text);
@@ -233,14 +230,16 @@ export class TextBatchTranslationService {
 
             if (madeProgress) {
               intermediateTexts = await this.updateTranslationsAndCache({
-                requestId: param.requestId,
                 newTranslations: new Map([...batchTranslations]),
                 translations: intermediateTexts,
-                sourceLanguage,
-                targetLanguage,
                 modelName,
                 cacheTag: normalizedCacheTag,
               });
+
+              for (const { indices } of batchTranslations.values()) {
+                this.removePendingIndices(pendingIndices, indices);
+                this.addAppendableIndices(appendableIndices, indices);
+              }
 
               // 진행률 보고: 완료된 텍스트 수 = 전체 - 남은 텍스트 수
               const completed = totalTexts - currentRemainingTexts.size;
@@ -271,6 +270,17 @@ export class TextBatchTranslationService {
                 currentRemainingTexts.set(text, indices);
               }
             }
+
+            exampleCursor = this.appendResolvedExamples({
+              requestId: param.requestId,
+              sourceTexts,
+              translations: intermediateTexts,
+              sourceLanguage,
+              targetLanguage,
+              appendableIndices,
+              pendingIndices,
+              cursor: exampleCursor,
+            });
 
             if (shouldReduceBatchSize) {
               maxBatchTextCount = this.reduceBatchSizeLimit(maxBatchTextCount, batchTexts.length);
@@ -336,15 +346,19 @@ export class TextBatchTranslationService {
         indices.forEach((index) => {
           intermediateTexts[index] = originalText;
         });
+        this.removePendingIndices(pendingIndices, indices);
         newTranslations.set(originalText, { text: originalText, indices });
       }
 
-      this.appendCacheHitExamples({
+      this.appendResolvedExamples({
         requestId: param.requestId,
+        sourceTexts,
+        translations: intermediateTexts,
         sourceLanguage,
         targetLanguage,
-        cacheHitExamples,
-        cursor: cacheHitExampleCursor,
+        appendableIndices,
+        pendingIndices,
+        cursor: exampleCursor,
       });
 
       if (strictFailureReasonsByText.size > 0) {
@@ -566,15 +580,9 @@ export class TextBatchTranslationService {
   ): Promise<{
     texts: string[];
     remainingTexts: Map<string, number[]>;
-    cacheHitExamples: Array<{ index: number; sourceText: string; translatedText: string }>;
   }> {
     const texts = new Array<string>(sourceTexts.length);
     const remainingTexts = new Map<string, number[]>();
-    const cacheHitExamples: Array<{
-      index: number;
-      sourceText: string;
-      translatedText: string;
-    }> = [];
     const cachedResults = await this.cacheManagerService.getTranslations(sourceTexts, cacheTag);
 
     sourceTexts.forEach((text, index) => {
@@ -586,13 +594,6 @@ export class TextBatchTranslationService {
 
       if (isCacheHit) {
         texts[index] = translatedText;
-        if (text.trim() !== '') {
-          cacheHitExamples.push({
-            index,
-            sourceText: text,
-            translatedText,
-          });
-        }
       } else {
         const indices = remainingTexts.get(text) || [];
         indices.push(index);
@@ -600,58 +601,77 @@ export class TextBatchTranslationService {
       }
     });
 
-    return { texts, remainingTexts, cacheHitExamples };
+    return { texts, remainingTexts };
   }
 
-  private getFirstIndexForBatch(
-    batchTexts: string[],
-    remainingTexts: Map<string, number[]>
-  ): number | undefined {
-    let firstIndex: number | undefined;
+  private collectPendingIndices(remainingTexts: Map<string, number[]>): Set<number> {
+    const pendingIndices = new Set<number>();
 
-    for (const text of batchTexts) {
-      const indices = remainingTexts.get(text) || [];
+    for (const indices of remainingTexts.values()) {
       for (const index of indices) {
-        if (firstIndex === undefined || index < firstIndex) {
-          firstIndex = index;
-        }
+        pendingIndices.add(index);
       }
     }
 
-    return firstIndex;
+    return pendingIndices;
   }
 
-  private appendCacheHitExamples({
+  private collectAppendableIndices(
+    sourceTexts: string[],
+    pendingIndices: Set<number>
+  ): Set<number> {
+    const appendableIndices = new Set<number>();
+
+    sourceTexts.forEach((text, index) => {
+      if (!pendingIndices.has(index) && text.trim() !== '') {
+        appendableIndices.add(index);
+      }
+    });
+
+    return appendableIndices;
+  }
+
+  private removePendingIndices(pendingIndices: Set<number>, indices: number[]): void {
+    for (const index of indices) {
+      pendingIndices.delete(index);
+    }
+  }
+
+  private addAppendableIndices(appendableIndices: Set<number>, indices: number[]): void {
+    for (const index of indices) {
+      appendableIndices.add(index);
+    }
+  }
+
+  private appendResolvedExamples({
     requestId,
+    sourceTexts,
+    translations,
     sourceLanguage,
     targetLanguage,
-    cacheHitExamples,
+    appendableIndices,
+    pendingIndices,
     cursor,
-    beforeIndexExclusive,
   }: {
     requestId: string;
+    sourceTexts: string[];
+    translations: string[];
     sourceLanguage: SourceLanguage;
     targetLanguage: TargetLanguage;
-    cacheHitExamples: Array<{ index: number; sourceText: string; translatedText: string }>;
+    appendableIndices: Set<number>;
+    pendingIndices: Set<number>;
     cursor: number;
-    beforeIndexExclusive?: number;
   }): number {
-    const sources: string[] = [];
-    const results: string[] = [];
+    let sources: string[] = [];
+    let results: string[] = [];
+    let bufferedSourceCharCount = 0;
     let nextCursor = cursor;
 
-    while (nextCursor < cacheHitExamples.length) {
-      const cacheHit = cacheHitExamples[nextCursor];
-      if (beforeIndexExclusive !== undefined && cacheHit.index >= beforeIndexExclusive) {
-        break;
+    const flush = () => {
+      if (sources.length === 0) {
+        return;
       }
 
-      sources.push(cacheHit.sourceText);
-      results.push(cacheHit.translatedText);
-      nextCursor++;
-    }
-
-    if (sources.length > 0) {
       this.exampleManagerService.appendCurrentExample(
         requestId,
         sourceLanguage,
@@ -659,7 +679,34 @@ export class TextBatchTranslationService {
         sources,
         results
       );
+
+      sources = [];
+      results = [];
+      bufferedSourceCharCount = 0;
+    };
+
+    while (nextCursor < sourceTexts.length && !pendingIndices.has(nextCursor)) {
+      const sourceText = sourceTexts[nextCursor];
+      const translatedText = translations[nextCursor];
+
+      if (appendableIndices.has(nextCursor) && sourceText.trim() !== '') {
+        if (
+          sources.length > 0 &&
+          bufferedSourceCharCount + sourceText.length > this.MAX_EXAMPLE_APPEND_CHAR_COUNT
+        ) {
+          flush();
+        }
+
+        sources.push(sourceText);
+        results.push(translatedText);
+        bufferedSourceCharCount += sourceText.length;
+        appendableIndices.delete(nextCursor);
+      }
+
+      nextCursor++;
     }
+
+    flush();
 
     return nextCursor;
   }
@@ -705,25 +752,17 @@ export class TextBatchTranslationService {
   }
 
   private async updateTranslationsAndCache({
-    requestId,
     newTranslations,
     translations,
-    sourceLanguage,
-    targetLanguage,
     modelName,
     cacheTag,
   }: {
-    requestId: string;
     newTranslations: Map<string, TranslationResult>;
     translations: string[];
-    sourceLanguage: SourceLanguage;
-    targetLanguage: TargetLanguage;
     modelName: string;
     cacheTag: string;
   }): Promise<string[]> {
     const translationsToCache = new Map<string, string>();
-    const sourceLines: string[] = [];
-    const resultLines: string[] = [];
     const copiedTranslations = deepClone(translations);
 
     for (const [originalText, { text: translatedText, indices }] of newTranslations) {
@@ -732,22 +771,9 @@ export class TextBatchTranslationService {
       indices.forEach((index) => {
         copiedTranslations[index] = translatedText;
       });
-
-      sourceLines.push(originalText);
-      resultLines.push(translatedText);
     }
 
     await this.cacheManagerService.setTranslations(translationsToCache, true, modelName, cacheTag);
-
-    if (sourceLines.length > 0) {
-      this.exampleManagerService.appendCurrentExample(
-        requestId,
-        sourceLanguage,
-        targetLanguage,
-        sourceLines,
-        resultLines
-      );
-    }
 
     return copiedTranslations;
   }


### PR DESCRIPTION
## 요약
- 검증을 통과한 캐시 히트를 요청별 example manager에 입력 순서대로 누적하도록 변경했습니다.
- 번역 배치 시작 전에는 해당 배치보다 앞선 캐시 결과만 먼저 주입하고, 요청 종료 시 뒤쪽 캐시 결과도 순서대로 반영합니다.
- 관련 회귀 테스트를 추가해 캐시 히트와 신규 번역이 섞인 경우의 example 누적 순서를 검증했습니다.

## 테스트
- yarn workspace @apps/backend test --runTestsByPath /home/brain-offloaded/vscode/formatted-docs-ai-translator/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
- yarn workspace @apps/backend lint
- pre-push hook: turbo build, turbo lint
