### PR TITLE
플레이스홀더 불일치 실패를 캐시에 기록

### DIFF
--- a/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
+++ b/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
@@ -47,8 +47,9 @@ const buildResponse = (): AiChatResponse => ({
 const createService = () => {
   const cacheManagerService = {
     getTranslations: jest.fn(),
+    setTranslation: jest.fn(),
     setTranslations: jest.fn(),
-  } satisfies Pick<ICacheManagerService, 'getTranslations' | 'setTranslations'>;
+  } satisfies Pick<ICacheManagerService, 'getTranslations' | 'setTranslation' | 'setTranslations'>;
 
   const tokenService = {
     getBatchGroups: jest.fn(),
@@ -132,14 +133,16 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       },
     ]);
     expect(translateUncachedTexts).toHaveBeenCalledTimes(3);
-    expect(cacheManagerService.setTranslations).toHaveBeenCalledTimes(1);
-    expect(cacheManagerService.setTranslations).toHaveBeenCalledWith(
-      new Map([[sourceText, sourceText]]),
+    expect(cacheManagerService.setTranslation).toHaveBeenCalledTimes(1);
+    expect(cacheManagerService.setTranslation).toHaveBeenCalledWith(
+      sourceText,
+      sourceText,
       false,
       'test-model',
       buildLanguageScopedCacheTag('default', SourceLanguage.ENGLISH, TargetLanguage.KOREAN),
       'placeholder_mismatch'
     );
+    expect(cacheManagerService.setTranslations).not.toHaveBeenCalled();
     expect(exampleManagerService.appendCurrentExample).not.toHaveBeenCalled();
   });
 
@@ -180,14 +183,16 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       },
     ]);
     expect(translateUncachedTexts).toHaveBeenCalledTimes(3);
-    expect(cacheManagerService.setTranslations).toHaveBeenCalledTimes(1);
-    expect(cacheManagerService.setTranslations).toHaveBeenCalledWith(
-      new Map([[sourceText, sourceText]]),
+    expect(cacheManagerService.setTranslation).toHaveBeenCalledTimes(1);
+    expect(cacheManagerService.setTranslation).toHaveBeenCalledWith(
+      sourceText,
+      sourceText,
       false,
       'test-model',
       buildLanguageScopedCacheTag('default', SourceLanguage.ENGLISH, TargetLanguage.KOREAN),
       'placeholder_mismatch'
     );
+    expect(cacheManagerService.setTranslations).not.toHaveBeenCalled();
     expect(exampleManagerService.appendCurrentExample).not.toHaveBeenCalled();
   });
 

--- a/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
+++ b/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
@@ -134,17 +134,15 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       },
     ]);
     expect(translateUncachedTexts).toHaveBeenCalledTimes(3);
-    expect(cacheManagerService.setTranslation).toHaveBeenCalledTimes(3);
-    expect(cacheManagerService.setTranslation).toHaveBeenNthCalledWith(
+    expect(cacheManagerService.setTranslations).toHaveBeenCalledTimes(3);
+    expect(cacheManagerService.setTranslations).toHaveBeenNthCalledWith(
       1,
-      sourceText,
-      '번역번역번역',
+      new Map([[sourceText, '번역번역번역']]),
       false,
       'test-model',
       buildLanguageScopedCacheTag('default', SourceLanguage.ENGLISH, TargetLanguage.KOREAN),
       'placeholder_mismatch'
     );
-    expect(cacheManagerService.setTranslations).not.toHaveBeenCalled();
     expect(exampleManagerService.appendCurrentExample).not.toHaveBeenCalled();
   });
 
@@ -186,17 +184,15 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       },
     ]);
     expect(translateUncachedTexts).toHaveBeenCalledTimes(3);
-    expect(cacheManagerService.setTranslation).toHaveBeenCalledTimes(3);
-    expect(cacheManagerService.setTranslation).toHaveBeenNthCalledWith(
+    expect(cacheManagerService.setTranslations).toHaveBeenCalledTimes(3);
+    expect(cacheManagerService.setTranslations).toHaveBeenNthCalledWith(
       1,
-      sourceText,
-      '첫 줄 둘째 줄',
+      new Map([[sourceText, '첫 줄 둘째 줄']]),
       false,
       'test-model',
       buildLanguageScopedCacheTag('default', SourceLanguage.ENGLISH, TargetLanguage.KOREAN),
       'placeholder_mismatch'
     );
-    expect(cacheManagerService.setTranslations).not.toHaveBeenCalled();
     expect(exampleManagerService.appendCurrentExample).not.toHaveBeenCalled();
   });
 
@@ -251,7 +247,22 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       },
     ]);
     expect(translateUncachedTexts).toHaveBeenCalledTimes(2);
-    expect(cacheManagerService.setTranslations).toHaveBeenCalledTimes(1);
+    expect(cacheManagerService.setTranslations).toHaveBeenCalledTimes(2);
+    expect(cacheManagerService.setTranslations).toHaveBeenNthCalledWith(
+      1,
+      new Map([[sourceText, '안녕하세요 세계']]),
+      false,
+      'test-model',
+      buildLanguageScopedCacheTag('default', SourceLanguage.ENGLISH, TargetLanguage.KOREAN),
+      'placeholder_mismatch'
+    );
+    expect(cacheManagerService.setTranslations).toHaveBeenNthCalledWith(
+      2,
+      new Map([[sourceText, translatedText]]),
+      true,
+      'test-model',
+      buildLanguageScopedCacheTag('default', SourceLanguage.ENGLISH, TargetLanguage.KOREAN)
+    );
     expect(exampleManagerService.appendCurrentExample).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
+++ b/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
@@ -91,6 +91,58 @@ const createService = () => {
 };
 
 describe('TextBatchTranslationService 검증 불일치 재시도', () => {
+  it('transtranstrans 플레이스홀더 불일치는 실패 캐시로 남긴다', async () => {
+    const sourceText = 'transtranstrans';
+    const { service, cacheManagerService, tokenService, exampleManagerService } = createService();
+
+    cacheManagerService.getTranslations.mockResolvedValue(new Map([[sourceText, null]]));
+    tokenService.getBatchGroups.mockResolvedValue([[sourceText]]);
+
+    const translateUncachedTexts = jest.fn().mockResolvedValue({
+      batchTranslations: new Map<string, TranslationResult>(),
+      response: buildResponse(),
+      shouldReduceBatchSize: false,
+      hasPartialData: false,
+      validationMismatchTexts: new Set([sourceText]),
+    });
+    (
+      service as unknown as {
+        translateUncachedTexts: typeof translateUncachedTexts;
+      }
+    ).translateUncachedTexts = translateUncachedTexts;
+
+    const result = await service.translateText({
+      requestId: 'req-transtranstrans',
+      sourceTexts: [sourceText],
+      promptPresetContent: '',
+      aiSettings: buildAiSettings(),
+      cacheTag: 'default',
+      placeholderPreservation: {
+        enabled: true,
+        rules: [{ pattern: 'transtranstrans', flags: '' }],
+      },
+    });
+
+    expect(result.texts).toEqual([sourceText]);
+    expect(result.strictMetaByIndex).toEqual([
+      {
+        strictFailed: true,
+        strictFailureReasons: ['placeholder_mismatch'],
+        strictFailureCount: 1,
+      },
+    ]);
+    expect(translateUncachedTexts).toHaveBeenCalledTimes(3);
+    expect(cacheManagerService.setTranslations).toHaveBeenCalledTimes(1);
+    expect(cacheManagerService.setTranslations).toHaveBeenCalledWith(
+      new Map([[sourceText, sourceText]]),
+      false,
+      'test-model',
+      buildLanguageScopedCacheTag('default', SourceLanguage.ENGLISH, TargetLanguage.KOREAN),
+      'placeholder_mismatch'
+    );
+    expect(exampleManagerService.appendCurrentExample).not.toHaveBeenCalled();
+  });
+
   it('검증 불일치가 반복되면 원문을 유지한다', async () => {
     const sourceText = '첫 줄\n둘째 줄';
     const { service, cacheManagerService, tokenService, exampleManagerService } = createService();

--- a/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
+++ b/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
@@ -1,5 +1,6 @@
 import { TextBatchTranslationService } from '../text-batch-translation.service';
 import { SourceLanguage, TargetLanguage } from '@apps/common/dist/language';
+import { buildLanguageScopedCacheTag } from '@apps/common/dist/utils/cache-tag';
 import {
   ModelProvider,
   TranslatorAiSettings,
@@ -127,7 +128,14 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       },
     ]);
     expect(translateUncachedTexts).toHaveBeenCalledTimes(3);
-    expect(cacheManagerService.setTranslations).not.toHaveBeenCalled();
+    expect(cacheManagerService.setTranslations).toHaveBeenCalledTimes(1);
+    expect(cacheManagerService.setTranslations).toHaveBeenCalledWith(
+      new Map([[sourceText, sourceText]]),
+      false,
+      'test-model',
+      buildLanguageScopedCacheTag('default', SourceLanguage.ENGLISH, TargetLanguage.KOREAN),
+      'placeholder_mismatch'
+    );
     expect(exampleManagerService.appendCurrentExample).not.toHaveBeenCalled();
   });
 

--- a/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
+++ b/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
@@ -105,6 +105,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       shouldReduceBatchSize: false,
       hasPartialData: false,
       validationMismatchTexts: new Set([sourceText]),
+      validationMismatchTranslations: new Map([[sourceText, '번역번역번역']]),
     });
     (
       service as unknown as {
@@ -133,10 +134,11 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       },
     ]);
     expect(translateUncachedTexts).toHaveBeenCalledTimes(3);
-    expect(cacheManagerService.setTranslation).toHaveBeenCalledTimes(1);
-    expect(cacheManagerService.setTranslation).toHaveBeenCalledWith(
+    expect(cacheManagerService.setTranslation).toHaveBeenCalledTimes(3);
+    expect(cacheManagerService.setTranslation).toHaveBeenNthCalledWith(
+      1,
       sourceText,
-      sourceText,
+      '번역번역번역',
       false,
       'test-model',
       buildLanguageScopedCacheTag('default', SourceLanguage.ENGLISH, TargetLanguage.KOREAN),
@@ -159,6 +161,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       shouldReduceBatchSize: false,
       hasPartialData: false,
       validationMismatchTexts: new Set([sourceText]),
+      validationMismatchTranslations: new Map([[sourceText, '첫 줄 둘째 줄']]),
     });
     (
       service as unknown as {
@@ -183,10 +186,11 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       },
     ]);
     expect(translateUncachedTexts).toHaveBeenCalledTimes(3);
-    expect(cacheManagerService.setTranslation).toHaveBeenCalledTimes(1);
-    expect(cacheManagerService.setTranslation).toHaveBeenCalledWith(
+    expect(cacheManagerService.setTranslation).toHaveBeenCalledTimes(3);
+    expect(cacheManagerService.setTranslation).toHaveBeenNthCalledWith(
+      1,
       sourceText,
-      sourceText,
+      '첫 줄 둘째 줄',
       false,
       'test-model',
       buildLanguageScopedCacheTag('default', SourceLanguage.ENGLISH, TargetLanguage.KOREAN),
@@ -212,6 +216,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
         shouldReduceBatchSize: false,
         hasPartialData: false,
         validationMismatchTexts: new Set([sourceText]),
+        validationMismatchTranslations: new Map([[sourceText, '안녕하세요 세계']]),
       })
       .mockResolvedValueOnce({
         batchTranslations: new Map<string, TranslationResult>([
@@ -221,6 +226,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
         shouldReduceBatchSize: false,
         hasPartialData: false,
         validationMismatchTexts: new Set<string>(),
+        validationMismatchTranslations: new Map<string, string>(),
       });
     (
       service as unknown as {
@@ -268,6 +274,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       shouldReduceBatchSize: false,
       hasPartialData: false,
       validationMismatchTexts: new Set<string>(),
+      validationMismatchTranslations: new Map<string, string>(),
     });
     (
       service as unknown as {
@@ -328,6 +335,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       shouldReduceBatchSize: false,
       hasPartialData: false,
       validationMismatchTexts: new Set<string>(),
+      validationMismatchTranslations: new Map<string, string>(),
     });
     (
       service as unknown as {
@@ -474,6 +482,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       shouldReduceBatchSize: false,
       hasPartialData: false,
       validationMismatchTexts: new Set<string>(),
+      validationMismatchTranslations: new Map<string, string>(),
     });
     (
       service as unknown as {
@@ -551,6 +560,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       shouldReduceBatchSize: false,
       hasPartialData: false,
       validationMismatchTexts: new Set<string>(),
+      validationMismatchTranslations: new Map<string, string>(),
     });
     (
       service as unknown as {
@@ -612,6 +622,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       shouldReduceBatchSize: false,
       hasPartialData: false,
       validationMismatchTexts: new Set<string>(),
+      validationMismatchTranslations: new Map<string, string>(),
     });
     (
       service as unknown as {
@@ -666,6 +677,7 @@ describe('TextBatchTranslationService 검증 불일치 재시도', () => {
       shouldReduceBatchSize: false,
       hasPartialData: false,
       validationMismatchTexts: new Set<string>(),
+      validationMismatchTranslations: new Map<string, string>(),
     });
     (
       service as unknown as {

--- a/apps/backend/src/nest/ai/services/ai-proxy.service.ts
+++ b/apps/backend/src/nest/ai/services/ai-proxy.service.ts
@@ -50,6 +50,7 @@ export class AiProxyService {
     translations: Map<string, TranslationResult>;
     hasPartialData: boolean;
     validationMismatchTexts: Set<string>;
+    validationMismatchTranslations: Map<string, string>;
   }> {
     return this.responseParser.parseTranslationResponse(
       response,

--- a/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
+++ b/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
@@ -361,6 +361,13 @@ export class TextBatchTranslationService {
         cursor: exampleCursor,
       });
 
+      await this.persistPlaceholderMismatchFailures({
+        sourceTexts,
+        strictFailureReasonsByText,
+        modelName,
+        cacheTag: normalizedCacheTag,
+      });
+
       if (strictFailureReasonsByText.size > 0) {
         this.logger.warn('엄격 검증 실패를 포함해 번역을 종료합니다.', {
           strictFailureTextCount: strictFailureReasonsByText.size,
@@ -426,6 +433,40 @@ export class TextBatchTranslationService {
         strictFailureCount: reasons.length,
       };
     });
+  }
+
+  private async persistPlaceholderMismatchFailures({
+    sourceTexts,
+    strictFailureReasonsByText,
+    modelName,
+    cacheTag,
+  }: {
+    sourceTexts: string[];
+    strictFailureReasonsByText: Map<string, Set<StrictFailureReason>>;
+    modelName: string;
+    cacheTag: string;
+  }): Promise<void> {
+    const failedTranslations = new Map<string, string>();
+
+    for (const text of sourceTexts) {
+      const reasons = strictFailureReasonsByText.get(text);
+      if (!reasons?.has('placeholder_mismatch')) {
+        continue;
+      }
+      failedTranslations.set(text, text);
+    }
+
+    if (failedTranslations.size === 0) {
+      return;
+    }
+
+    await this.cacheManagerService.setTranslations(
+      failedTranslations,
+      false,
+      modelName,
+      cacheTag,
+      'placeholder_mismatch'
+    );
   }
 
   private async translateUncachedTexts({

--- a/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
+++ b/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
@@ -447,16 +447,13 @@ export class TextBatchTranslationService {
       return;
     }
 
-    for (const [sourceText, translatedText] of mismatchTranslations.entries()) {
-      await this.cacheManagerService.setTranslation(
-        sourceText,
-        translatedText,
-        false,
-        modelName,
-        cacheTag,
-        'placeholder_mismatch'
-      );
-    }
+    await this.cacheManagerService.setTranslations(
+      mismatchTranslations,
+      false,
+      modelName,
+      cacheTag,
+      'placeholder_mismatch'
+    );
 
     this.logger.debug('플레이스홀더 불일치 실패를 캐시에 기록했습니다.', {
       count: mismatchTranslations.size,

--- a/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
+++ b/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
@@ -115,7 +115,6 @@ export class TextBatchTranslationService {
       let stableBatchSuccessCount = 0;
       const validationMismatchCounts = new Map<string, number>();
       const strictFailureReasonsByText = new Map<string, Set<StrictFailureReason>>();
-      const persistedPlaceholderMismatchTexts = new Set<string>();
 
       while (currentRemainingTexts.size > 0) {
         const remainingTextArray = Array.from(currentRemainingTexts.keys());
@@ -145,6 +144,7 @@ export class TextBatchTranslationService {
               shouldReduceBatchSize,
               hasPartialData,
               validationMismatchTexts,
+              validationMismatchTranslations,
             } = await this.translateUncachedTexts({
               requestId: param.requestId,
               remainingTexts: batchRemainingTexts,
@@ -158,6 +158,11 @@ export class TextBatchTranslationService {
             const hasValidationMismatch = validationMismatchTexts.size > 0;
             const giveUpTexts = new Set<string>();
             if (hasValidationMismatch) {
+              await this.persistValidationMismatchTranslations({
+                mismatchTranslations: validationMismatchTranslations,
+                modelName,
+                cacheTag: normalizedCacheTag,
+              });
               for (const text of validationMismatchTexts) {
                 this.markStrictFailure(strictFailureReasonsByText, text, 'placeholder_mismatch');
                 const nextCount = (validationMismatchCounts.get(text) ?? 0) + 1;
@@ -179,12 +184,6 @@ export class TextBatchTranslationService {
                 }
                 this.logger.warn('검증 불일치가 반복되어 원문을 유지합니다.', {
                   count: giveUpTexts.size,
-                });
-                await this.persistPlaceholderMismatchFailureTexts({
-                  texts: Array.from(giveUpTexts),
-                  modelName,
-                  cacheTag: normalizedCacheTag,
-                  persistedTexts: persistedPlaceholderMismatchTexts,
                 });
               }
               stableBatchSuccessCount = 0;
@@ -368,14 +367,6 @@ export class TextBatchTranslationService {
         cursor: exampleCursor,
       });
 
-      await this.persistPlaceholderMismatchFailures({
-        sourceTexts,
-        strictFailureReasonsByText,
-        modelName,
-        cacheTag: normalizedCacheTag,
-        persistedTexts: persistedPlaceholderMismatchTexts,
-      });
-
       if (strictFailureReasonsByText.size > 0) {
         this.logger.warn('엄격 검증 실패를 포함해 번역을 종료합니다.', {
           strictFailureTextCount: strictFailureReasonsByText.size,
@@ -443,71 +434,32 @@ export class TextBatchTranslationService {
     });
   }
 
-  private async persistPlaceholderMismatchFailures({
-    sourceTexts,
-    strictFailureReasonsByText,
+  private async persistValidationMismatchTranslations({
+    mismatchTranslations,
     modelName,
     cacheTag,
-    persistedTexts,
   }: {
-    sourceTexts: string[];
-    strictFailureReasonsByText: Map<string, Set<StrictFailureReason>>;
+    mismatchTranslations: Map<string, string>;
     modelName: string;
     cacheTag: string;
-    persistedTexts: Set<string>;
   }): Promise<void> {
-    const textsToPersist: string[] = [];
-
-    for (const text of sourceTexts) {
-      if (persistedTexts.has(text)) {
-        continue;
-      }
-      const reasons = strictFailureReasonsByText.get(text);
-      if (!reasons?.has('placeholder_mismatch')) {
-        continue;
-      }
-      textsToPersist.push(text);
-    }
-
-    await this.persistPlaceholderMismatchFailureTexts({
-      texts: textsToPersist,
-      modelName,
-      cacheTag,
-      persistedTexts,
-    });
-  }
-
-  private async persistPlaceholderMismatchFailureTexts({
-    texts,
-    modelName,
-    cacheTag,
-    persistedTexts,
-  }: {
-    texts: string[];
-    modelName: string;
-    cacheTag: string;
-    persistedTexts: Set<string>;
-  }): Promise<void> {
-    const uniqueTexts = texts.filter((text) => !persistedTexts.has(text));
-
-    if (uniqueTexts.length === 0) {
+    if (mismatchTranslations.size === 0) {
       return;
     }
 
-    for (const text of uniqueTexts) {
+    for (const [sourceText, translatedText] of mismatchTranslations.entries()) {
       await this.cacheManagerService.setTranslation(
-        text,
-        text,
+        sourceText,
+        translatedText,
         false,
         modelName,
         cacheTag,
         'placeholder_mismatch'
       );
-      persistedTexts.add(text);
     }
 
     this.logger.debug('플레이스홀더 불일치 실패를 캐시에 기록했습니다.', {
-      count: uniqueTexts.length,
+      count: mismatchTranslations.size,
       cacheTag,
     });
   }
@@ -534,6 +486,7 @@ export class TextBatchTranslationService {
     shouldReduceBatchSize: boolean;
     hasPartialData: boolean;
     validationMismatchTexts: Set<string>;
+    validationMismatchTranslations: Map<string, string>;
   }> {
     const {
       sourceLanguage,
@@ -578,6 +531,7 @@ export class TextBatchTranslationService {
         translations: batchTranslations,
         hasPartialData,
         validationMismatchTexts,
+        validationMismatchTranslations,
       } = await this.aiProxy.parseTranslationResponse(
         response,
         remainingTexts,
@@ -590,6 +544,7 @@ export class TextBatchTranslationService {
         shouldReduceBatchSize: this.aiProxy.isFinishedByMaxTokens(response) || hasPartialData,
         hasPartialData,
         validationMismatchTexts,
+        validationMismatchTranslations,
       };
     } catch (error) {
       const translationsToCache = new Map<string, string>();

--- a/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
+++ b/apps/backend/src/nest/ai/services/text-batch-translation.service.ts
@@ -115,6 +115,7 @@ export class TextBatchTranslationService {
       let stableBatchSuccessCount = 0;
       const validationMismatchCounts = new Map<string, number>();
       const strictFailureReasonsByText = new Map<string, Set<StrictFailureReason>>();
+      const persistedPlaceholderMismatchTexts = new Set<string>();
 
       while (currentRemainingTexts.size > 0) {
         const remainingTextArray = Array.from(currentRemainingTexts.keys());
@@ -178,6 +179,12 @@ export class TextBatchTranslationService {
                 }
                 this.logger.warn('검증 불일치가 반복되어 원문을 유지합니다.', {
                   count: giveUpTexts.size,
+                });
+                await this.persistPlaceholderMismatchFailureTexts({
+                  texts: Array.from(giveUpTexts),
+                  modelName,
+                  cacheTag: normalizedCacheTag,
+                  persistedTexts: persistedPlaceholderMismatchTexts,
                 });
               }
               stableBatchSuccessCount = 0;
@@ -366,6 +373,7 @@ export class TextBatchTranslationService {
         strictFailureReasonsByText,
         modelName,
         cacheTag: normalizedCacheTag,
+        persistedTexts: persistedPlaceholderMismatchTexts,
       });
 
       if (strictFailureReasonsByText.size > 0) {
@@ -440,33 +448,68 @@ export class TextBatchTranslationService {
     strictFailureReasonsByText,
     modelName,
     cacheTag,
+    persistedTexts,
   }: {
     sourceTexts: string[];
     strictFailureReasonsByText: Map<string, Set<StrictFailureReason>>;
     modelName: string;
     cacheTag: string;
+    persistedTexts: Set<string>;
   }): Promise<void> {
-    const failedTranslations = new Map<string, string>();
+    const textsToPersist: string[] = [];
 
     for (const text of sourceTexts) {
+      if (persistedTexts.has(text)) {
+        continue;
+      }
       const reasons = strictFailureReasonsByText.get(text);
       if (!reasons?.has('placeholder_mismatch')) {
         continue;
       }
-      failedTranslations.set(text, text);
+      textsToPersist.push(text);
     }
 
-    if (failedTranslations.size === 0) {
+    await this.persistPlaceholderMismatchFailureTexts({
+      texts: textsToPersist,
+      modelName,
+      cacheTag,
+      persistedTexts,
+    });
+  }
+
+  private async persistPlaceholderMismatchFailureTexts({
+    texts,
+    modelName,
+    cacheTag,
+    persistedTexts,
+  }: {
+    texts: string[];
+    modelName: string;
+    cacheTag: string;
+    persistedTexts: Set<string>;
+  }): Promise<void> {
+    const uniqueTexts = texts.filter((text) => !persistedTexts.has(text));
+
+    if (uniqueTexts.length === 0) {
       return;
     }
 
-    await this.cacheManagerService.setTranslations(
-      failedTranslations,
-      false,
-      modelName,
+    for (const text of uniqueTexts) {
+      await this.cacheManagerService.setTranslation(
+        text,
+        text,
+        false,
+        modelName,
+        cacheTag,
+        'placeholder_mismatch'
+      );
+      persistedTexts.add(text);
+    }
+
+    this.logger.debug('플레이스홀더 불일치 실패를 캐시에 기록했습니다.', {
+      count: uniqueTexts.length,
       cacheTag,
-      'placeholder_mismatch'
-    );
+    });
   }
 
   private async translateUncachedTexts({

--- a/apps/backend/src/nest/ai/services/translation-response-parser.service.ts
+++ b/apps/backend/src/nest/ai/services/translation-response-parser.service.ts
@@ -63,6 +63,7 @@ export class TranslationResponseParser {
     translations: Map<string, TranslationResult>;
     hasPartialData: boolean;
     validationMismatchTexts: Set<string>;
+    validationMismatchTranslations: Map<string, string>;
   } {
     const responseText = this.getResponseText(response);
     const { matches, hasPartialData } = this.parseSegmentMatches(responseText);
@@ -73,6 +74,7 @@ export class TranslationResponseParser {
     let expectedIds: number[] = [];
     let unexpectedIdCount: number | undefined;
     const validationMismatchTexts = new Set<string>();
+    const validationMismatchTranslations = new Map<string, string>();
 
     if (useStrictIdMatching && expectedIdToText) {
       expectedIds = Array.from(expectedIdToText.keys());
@@ -82,6 +84,7 @@ export class TranslationResponseParser {
         expectedIdToText,
         remainingTexts,
         validationMismatchTexts,
+        validationMismatchTranslations,
         placeholderPreservation
       );
       translations = strictResult.translations;
@@ -95,6 +98,7 @@ export class TranslationResponseParser {
         remainingTextArray,
         remainingTexts,
         validationMismatchTexts,
+        validationMismatchTranslations,
         placeholderPreservation
       );
       translations = fallbackResult.translations;
@@ -117,7 +121,12 @@ export class TranslationResponseParser {
       unexpectedIdCount,
     });
 
-    return { translations, hasPartialData, validationMismatchTexts };
+    return {
+      translations,
+      hasPartialData,
+      validationMismatchTexts,
+      validationMismatchTranslations,
+    };
   }
 
   private getResponseText(response: AiChatResponse): string {
@@ -358,6 +367,7 @@ export class TranslationResponseParser {
     remainingTextArray: string[],
     remainingTexts: Map<string, number[]>,
     validationMismatchTexts: Set<string>,
+    validationMismatchTranslations: Map<string, string>,
     placeholderPreservation?: PlaceholderPreservationSettings
   ): { translations: Map<string, TranslationResult>; excludeFrom: number; offset: number } {
     const offset = this.calculateOffset(matches);
@@ -376,6 +386,7 @@ export class TranslationResponseParser {
       remainingTextArray,
       remainingTexts,
       validationMismatchTexts,
+      validationMismatchTranslations,
       placeholderPreservation
     );
     return { translations, excludeFrom, offset };
@@ -387,6 +398,7 @@ export class TranslationResponseParser {
     expectedIdToText: Map<number, string>,
     remainingTexts: Map<string, number[]>,
     validationMismatchTexts: Set<string>,
+    validationMismatchTranslations: Map<string, string>,
     placeholderPreservation?: PlaceholderPreservationSettings
   ): {
     translations: Map<string, TranslationResult>;
@@ -430,6 +442,7 @@ export class TranslationResponseParser {
         });
         if (mismatchDetail) {
           validationMismatchTexts.add(originalText);
+          validationMismatchTranslations.set(originalText, translatedText);
           this.logger.warn('플레이스홀더 보존 불일치로 번역 제외', {
             id,
             originalText,
@@ -465,6 +478,7 @@ export class TranslationResponseParser {
     remainingTextArray: string[],
     remainingTexts: Map<string, number[]>,
     validationMismatchTexts: Set<string>,
+    validationMismatchTranslations: Map<string, string>,
     placeholderPreservation?: PlaceholderPreservationSettings
   ): Map<string, TranslationResult> {
     const translations = new Map<string, TranslationResult>();
@@ -489,6 +503,7 @@ export class TranslationResponseParser {
         });
         if (mismatchDetail) {
           validationMismatchTexts.add(originalText);
+          validationMismatchTranslations.set(originalText, translatedText);
           this.logger.warn('플레이스홀더 보존 불일치로 번역 제외', {
             id,
             normalizedId,

--- a/apps/backend/src/nest/cache/cache-manager/db-cache-manager/services/i-db-cache-manager-service.ts
+++ b/apps/backend/src/nest/cache/cache-manager/db-cache-manager/services/i-db-cache-manager-service.ts
@@ -30,14 +30,16 @@ export interface IDbCacheManagerService {
     translation: string,
     success?: boolean,
     modelName?: string,
-    cacheTag?: string
+    cacheTag?: string,
+    error?: string
   ): Promise<void>;
   getTranslations(texts: string[], cacheTag: string): Promise<Map<string, string | null>>;
   setTranslations(
     translations: Map<string, string>,
     success?: boolean,
     modelName?: string,
-    cacheTag?: string
+    cacheTag?: string,
+    error?: string
   ): Promise<void>;
 
   // 이력 관련 메서드

--- a/apps/backend/src/nest/cache/cache-manager/db-cache-manager/services/sqlite-cache-manager.service.ts
+++ b/apps/backend/src/nest/cache/cache-manager/db-cache-manager/services/sqlite-cache-manager.service.ts
@@ -53,7 +53,7 @@ export class SqliteCacheManagerService implements IDbCacheManagerService {
         success,
         modelName,
         cacheTag,
-        error
+        error ?? null
       );
     } catch (error) {
       this.logger.error('번역 캐시 저장 중 오류:', { error });
@@ -119,7 +119,7 @@ export class SqliteCacheManagerService implements IDbCacheManagerService {
         success,
         modelName,
         cacheTag,
-        error
+        error ?? null
       );
     } catch (error) {
       this.logger.error('번역 캐시 일괄 저장 중 오류:', { error, size: translations.size });

--- a/apps/backend/src/nest/cache/cache-manager/db-cache-manager/services/sqlite-cache-manager.service.ts
+++ b/apps/backend/src/nest/cache/cache-manager/db-cache-manager/services/sqlite-cache-manager.service.ts
@@ -43,10 +43,18 @@ export class SqliteCacheManagerService implements IDbCacheManagerService {
     translation: string,
     success: boolean = true,
     modelName: string = 'unknown',
-    cacheTag: string = DEFAULT_CACHE_TAG
+    cacheTag: string = DEFAULT_CACHE_TAG,
+    error?: string
   ): Promise<void> {
     try {
-      await this.translationLoader.saveTranslation(text, translation, success, modelName, cacheTag);
+      await this.translationLoader.saveTranslation(
+        text,
+        translation,
+        success,
+        modelName,
+        cacheTag,
+        error
+      );
     } catch (error) {
       this.logger.error('번역 캐시 저장 중 오류:', { error });
     }
@@ -59,7 +67,8 @@ export class SqliteCacheManagerService implements IDbCacheManagerService {
         history.target,
         history.success,
         history.model,
-        history.cacheTag || DEFAULT_CACHE_TAG
+        history.cacheTag || DEFAULT_CACHE_TAG,
+        history.error || null
       );
     } catch (error) {
       this.logger.error('번역 이력 저장 중 오류:', { error });
@@ -101,10 +110,17 @@ export class SqliteCacheManagerService implements IDbCacheManagerService {
     translations: Map<string, string>,
     success: boolean = true,
     modelName: string = 'unknown',
-    cacheTag: string = DEFAULT_CACHE_TAG
+    cacheTag: string = DEFAULT_CACHE_TAG,
+    error?: string
   ): Promise<void> {
     try {
-      await this.translationLoader.saveManyTranslations(translations, success, modelName, cacheTag);
+      await this.translationLoader.saveManyTranslations(
+        translations,
+        success,
+        modelName,
+        cacheTag,
+        error
+      );
     } catch (error) {
       this.logger.error('번역 캐시 일괄 저장 중 오류:', { error, size: translations.size });
     }

--- a/apps/backend/src/nest/cache/cache-manager/services/__tests__/cache-manager.service.spec.ts
+++ b/apps/backend/src/nest/cache/cache-manager/services/__tests__/cache-manager.service.spec.ts
@@ -12,10 +12,11 @@ describe('CacheManagerService - cache tag operations', () => {
       invalidate: jest.fn(),
       invalidateMany: jest.fn().mockResolvedValue(undefined),
       setTranslation: jest.fn(),
+      setTranslations: jest.fn(),
       getTranslation: jest.fn(),
     } satisfies Pick<
       IMemoryCacheManagerService,
-      'invalidate' | 'invalidateMany' | 'setTranslation' | 'getTranslation'
+      'invalidate' | 'invalidateMany' | 'setTranslation' | 'setTranslations' | 'getTranslation'
     >;
 
     const dbCacheManagerServiceMock = {
@@ -24,6 +25,8 @@ describe('CacheManagerService - cache tag operations', () => {
       findTranslationsByCondition: jest.fn(),
       updateTranslationCacheTag: jest.fn().mockResolvedValue(undefined),
       findTranslationsByIds: jest.fn(),
+      setTranslation: jest.fn().mockResolvedValue(undefined),
+      setTranslations: jest.fn().mockResolvedValue(undefined),
     } satisfies Pick<
       IDbCacheManagerService,
       | 'findCacheTagById'
@@ -31,6 +34,8 @@ describe('CacheManagerService - cache tag operations', () => {
       | 'findTranslationsByCondition'
       | 'updateTranslationCacheTag'
       | 'findTranslationsByIds'
+      | 'setTranslation'
+      | 'setTranslations'
     >;
 
     const commandBusMock = { execute: jest.fn() } satisfies Pick<CacheCommandBus, 'execute'>;
@@ -157,5 +162,60 @@ describe('CacheManagerService - cache tag operations', () => {
       buildMemoryCacheKey('sample', 'before-tag'),
       buildMemoryCacheKey('sample', 'after-tag'),
     ]);
+  });
+
+  it('실패한 번역 저장은 메모리 캐시를 무효화하고 DB에만 남긴다', async () => {
+    const { service, memoryCacheManagerService, dbCacheManagerService } = createService();
+
+    await service.setTranslation(
+      'source-text',
+      'source-text',
+      false,
+      'test-model',
+      'default_en-to-ko',
+      'placeholder_mismatch'
+    );
+
+    expect(memoryCacheManagerService.invalidate).toHaveBeenCalledWith(
+      buildMemoryCacheKey('source-text', 'default_en-to-ko')
+    );
+    expect(memoryCacheManagerService.setTranslation).not.toHaveBeenCalled();
+    expect(dbCacheManagerService.setTranslation).toHaveBeenCalledWith(
+      'source-text',
+      'source-text',
+      false,
+      'test-model',
+      'default_en-to-ko',
+      'placeholder_mismatch'
+    );
+  });
+
+  it('실패한 다중 번역 저장은 메모리 캐시를 일괄 무효화한다', async () => {
+    const { service, memoryCacheManagerService, dbCacheManagerService } = createService();
+    const failedTranslations = new Map([
+      ['first', 'first'],
+      ['second', 'second'],
+    ]);
+
+    await service.setTranslations(
+      failedTranslations,
+      false,
+      'test-model',
+      'default_en-to-ko',
+      'placeholder_mismatch'
+    );
+
+    expect(memoryCacheManagerService.invalidateMany).toHaveBeenCalledWith([
+      buildMemoryCacheKey('first', 'default_en-to-ko'),
+      buildMemoryCacheKey('second', 'default_en-to-ko'),
+    ]);
+    expect(memoryCacheManagerService.setTranslations).not.toHaveBeenCalled();
+    expect(dbCacheManagerService.setTranslations).toHaveBeenCalledWith(
+      failedTranslations,
+      false,
+      'test-model',
+      'default_en-to-ko',
+      'placeholder_mismatch'
+    );
   });
 });

--- a/apps/backend/src/nest/cache/cache-manager/services/__tests__/cache-manager.service.spec.ts
+++ b/apps/backend/src/nest/cache/cache-manager/services/__tests__/cache-manager.service.spec.ts
@@ -1,5 +1,6 @@
 import { CacheManagerService } from '../cache-manager.service';
 import { buildMemoryCacheKey } from '../../utils/cache-key';
+import { DEFAULT_CACHE_TAG } from '@apps/common/dist/constants/cache';
 import type { IMemoryCacheManagerService } from '../../memory-cache-manager/services/i-memory-cache-manager-service';
 import type { IDbCacheManagerService } from '../../db-cache-manager/services/i-db-cache-manager-service';
 import type { CacheCommandBus } from '@/nest/cache/commands/command-bus.service';
@@ -215,6 +216,31 @@ describe('CacheManagerService - cache tag operations', () => {
       false,
       'test-model',
       'default_en-to-ko',
+      'placeholder_mismatch'
+    );
+  });
+
+  it('기본 태그의 실패한 다중 번역 저장은 plain 메모리 키를 무효화한다', async () => {
+    const { service, memoryCacheManagerService, dbCacheManagerService } = createService();
+    const failedTranslations = new Map([
+      ['first', 'first-failed'],
+      ['second', 'second-failed'],
+    ]);
+
+    await service.setTranslations(
+      failedTranslations,
+      false,
+      'test-model',
+      undefined,
+      'placeholder_mismatch'
+    );
+
+    expect(memoryCacheManagerService.invalidateMany).toHaveBeenCalledWith(['first', 'second']);
+    expect(dbCacheManagerService.setTranslations).toHaveBeenCalledWith(
+      failedTranslations,
+      false,
+      'test-model',
+      DEFAULT_CACHE_TAG,
       'placeholder_mismatch'
     );
   });

--- a/apps/backend/src/nest/cache/cache-manager/services/cache-manager.service.ts
+++ b/apps/backend/src/nest/cache/cache-manager/services/cache-manager.service.ts
@@ -187,15 +187,27 @@ export class CacheManagerService implements ICacheManagerService {
     translation: string,
     success: boolean = true,
     modelName?: string,
-    cacheTag?: string
+    cacheTag?: string,
+    error?: string
   ): Promise<void> {
     const normalizedTag = cacheTag === undefined ? null : normalizeCacheTag(cacheTag);
     const dbTag = normalizedTag ?? DEFAULT_CACHE_TAG;
     const memoryKey = normalizedTag ? buildMemoryCacheKey(text, normalizedTag) : text;
-    // 메모리와 DB 모두에 저장
+    // 성공한 결과만 메모리 캐시에 유지하고, 실패 결과는 DB/이력에만 남깁니다.
+    const memoryOperation = success
+      ? this.memoryCacheManagerService.setTranslation(memoryKey, translation)
+      : this.memoryCacheManagerService.invalidate(memoryKey);
+
     await Promise.all([
-      this.memoryCacheManagerService.setTranslation(memoryKey, translation),
-      this.dbCacheManagerService.setTranslation(text, translation, success, modelName, dbTag),
+      memoryOperation,
+      this.dbCacheManagerService.setTranslation(
+        text,
+        translation,
+        success,
+        modelName,
+        dbTag,
+        error
+      ),
     ]);
   }
 
@@ -258,21 +270,29 @@ export class CacheManagerService implements ICacheManagerService {
     translations: Map<string, string>,
     success: boolean = true,
     modelName?: string,
-    cacheTag?: string
+    cacheTag?: string,
+    error?: string
   ): Promise<void> {
     const normalizedTag = cacheTag === undefined ? null : normalizeCacheTag(cacheTag);
     const dbTag = normalizedTag ?? DEFAULT_CACHE_TAG;
-    // 메모리와 DB 모두에 저장
-    await Promise.all([
-      this.memoryCacheManagerService.setTranslations(
-        new Map(
-          Array.from(translations.entries()).map(([source, value]) => [
-            normalizedTag ? buildMemoryCacheKey(source, normalizedTag) : source,
-            value,
-          ])
+    const memoryEntries = Array.from(translations.keys()).map((source) => ({
+      source,
+      cacheTag: dbTag,
+    }));
+    const memoryOperation = success
+      ? this.memoryCacheManagerService.setTranslations(
+          new Map(
+            Array.from(translations.entries()).map(([source, value]) => [
+              normalizedTag ? buildMemoryCacheKey(source, normalizedTag) : source,
+              value,
+            ])
+          )
         )
-      ),
-      this.dbCacheManagerService.setTranslations(translations, success, modelName, dbTag),
+      : this.invalidateMemoryCacheMany(memoryEntries);
+
+    await Promise.all([
+      memoryOperation,
+      this.dbCacheManagerService.setTranslations(translations, success, modelName, dbTag, error),
     ]);
   }
 

--- a/apps/backend/src/nest/cache/cache-manager/services/cache-manager.service.ts
+++ b/apps/backend/src/nest/cache/cache-manager/services/cache-manager.service.ts
@@ -35,6 +35,10 @@ export class CacheManagerService implements ICacheManagerService {
     private readonly logger: LoggerService
   ) {}
 
+  private getMemoryCacheKey(source: string, cacheTag?: string | null): string {
+    return cacheTag ? buildMemoryCacheKey(source, cacheTag) : source;
+  }
+
   /**
    * 메모리 캐시의 특정 항목을 무효화합니다.
    * @param text 무효화할 원본 텍스트
@@ -164,7 +168,7 @@ export class CacheManagerService implements ICacheManagerService {
   public async getTranslation(text: string, cacheTag?: string): Promise<string | null> {
     if (!CACHE_ENABLED) return null;
     const normalizedTag = cacheTag === undefined ? null : normalizeCacheTag(cacheTag);
-    const memoryKey = normalizedTag ? buildMemoryCacheKey(text, normalizedTag) : text;
+    const memoryKey = this.getMemoryCacheKey(text, normalizedTag);
     // 먼저 메모리 캐시에서 검색
     let translation = await this.memoryCacheManagerService.getTranslation(memoryKey);
 
@@ -192,7 +196,7 @@ export class CacheManagerService implements ICacheManagerService {
   ): Promise<void> {
     const normalizedTag = cacheTag === undefined ? null : normalizeCacheTag(cacheTag);
     const dbTag = normalizedTag ?? DEFAULT_CACHE_TAG;
-    const memoryKey = normalizedTag ? buildMemoryCacheKey(text, normalizedTag) : text;
+    const memoryKey = this.getMemoryCacheKey(text, normalizedTag);
     // 성공한 결과만 메모리 캐시에 유지하고, 실패 결과는 DB/이력에만 남깁니다.
     const memoryOperation = success
       ? this.memoryCacheManagerService.setTranslation(memoryKey, translation)
@@ -275,20 +279,19 @@ export class CacheManagerService implements ICacheManagerService {
   ): Promise<void> {
     const normalizedTag = cacheTag === undefined ? null : normalizeCacheTag(cacheTag);
     const dbTag = normalizedTag ?? DEFAULT_CACHE_TAG;
-    const memoryEntries = Array.from(translations.keys()).map((source) => ({
-      source,
-      cacheTag: dbTag,
-    }));
+    const memoryKeys = Array.from(translations.keys()).map((source) =>
+      this.getMemoryCacheKey(source, normalizedTag)
+    );
     const memoryOperation = success
       ? this.memoryCacheManagerService.setTranslations(
           new Map(
             Array.from(translations.entries()).map(([source, value]) => [
-              normalizedTag ? buildMemoryCacheKey(source, normalizedTag) : source,
+              this.getMemoryCacheKey(source, normalizedTag),
               value,
             ])
           )
         )
-      : this.invalidateMemoryCacheMany(memoryEntries);
+      : this.memoryCacheManagerService.invalidateMany(memoryKeys);
 
     await Promise.all([
       memoryOperation,

--- a/apps/backend/src/nest/cache/cache-manager/services/i-cache-manager-service.ts
+++ b/apps/backend/src/nest/cache/cache-manager/services/i-cache-manager-service.ts
@@ -19,14 +19,16 @@ export interface ICacheManagerService {
     translation: string,
     success?: boolean,
     modelName?: string,
-    cacheTag?: string
+    cacheTag?: string,
+    error?: string
   ): Promise<void>;
   getTranslations(texts: string[], cacheTag: string): Promise<Map<string, string | null>>;
   setTranslations(
     translations: Map<string, string>,
     success?: boolean,
     modelName?: string,
-    cacheTag?: string
+    cacheTag?: string,
+    error?: string
   ): Promise<void>;
   addTranslationHistory(history: TranslationHistory): Promise<void>;
   getTranslationHistory(source: string, cacheTag: string): Promise<TranslationHistory[]>;

--- a/apps/backend/src/nest/cache/loader/translation-loader/translation-loader.service.spec.ts
+++ b/apps/backend/src/nest/cache/loader/translation-loader/translation-loader.service.spec.ts
@@ -1,0 +1,162 @@
+import { DEFAULT_CACHE_TAG } from '@apps/common/dist/constants/cache';
+import { TranslationLoaderService } from './translation-loader.service';
+import type { PrismaService } from '@/nest/db/prisma/prisma.service';
+import type { LoggerService } from '@/nest/logger/logger.service';
+
+describe('TranslationLoaderService 실패 이력 저장', () => {
+  const createService = () => {
+    const client = {
+      cacheTag: {
+        upsert: jest.fn().mockResolvedValue({ id: 1, name: DEFAULT_CACHE_TAG }),
+      },
+      translation: {
+        findUnique: jest.fn(),
+        upsert: jest.fn(),
+      },
+      translationHistory: {
+        create: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    const prisma = {
+      $transaction: jest.fn(async (callback: (tx: typeof client) => unknown) => callback(client)),
+    } as unknown as PrismaService;
+
+    const logger = {
+      error: jest.fn(),
+    } as unknown as LoggerService;
+
+    const service = new TranslationLoaderService(prisma, logger);
+    const clearSourceCacheSpy = jest
+      .spyOn(service, 'clearSourceCache')
+      .mockImplementation(() => {});
+
+    return { service, client, clearSourceCacheSpy };
+  };
+
+  it('기존 성공 캐시가 있으면 실패 저장 시 current row는 유지하고 history만 추가한다', async () => {
+    const { service, client } = createService();
+    client.translation.findUnique.mockResolvedValue({
+      id: 10,
+      source: 'source-text',
+      target: '기존 성공 번역',
+      success: true,
+      cacheTagId: 1,
+      cacheTag: { name: DEFAULT_CACHE_TAG },
+    });
+
+    await service.saveTranslation(
+      'source-text',
+      '실패한 번역문',
+      false,
+      'test-model',
+      DEFAULT_CACHE_TAG,
+      'placeholder_mismatch'
+    );
+
+    expect(client.translation.upsert).not.toHaveBeenCalled();
+    expect(client.translationHistory.create).toHaveBeenCalledWith({
+      data: {
+        translationId: 10,
+        source: 'source-text',
+        target: '실패한 번역문',
+        success: false,
+        error: 'placeholder_mismatch',
+        model: 'test-model',
+        cacheTagId: 1,
+      },
+    });
+  });
+
+  it('기존 성공 캐시가 없으면 실패 저장도 current row를 생성한다', async () => {
+    const { service, client } = createService();
+    client.translation.findUnique.mockResolvedValue(null);
+    client.translation.upsert.mockResolvedValue({
+      id: 11,
+      source: 'new-source',
+      target: '실패한 번역문',
+      success: false,
+      cacheTagId: 1,
+      cacheTag: { name: DEFAULT_CACHE_TAG },
+    });
+
+    await service.saveTranslation(
+      'new-source',
+      '실패한 번역문',
+      false,
+      'test-model',
+      DEFAULT_CACHE_TAG,
+      'placeholder_mismatch'
+    );
+
+    expect(client.translation.upsert).toHaveBeenCalledTimes(1);
+    expect(client.translationHistory.create).toHaveBeenCalledWith({
+      data: {
+        translationId: 11,
+        source: 'new-source',
+        target: '실패한 번역문',
+        success: false,
+        error: 'placeholder_mismatch',
+        model: 'test-model',
+        cacheTagId: 1,
+      },
+    });
+  });
+
+  it('다중 실패 저장도 기존 성공 current row는 보존한다', async () => {
+    const { service, client } = createService();
+    client.translation.findUnique
+      .mockResolvedValueOnce({
+        id: 21,
+        source: 'cached-source',
+        target: '기존 성공 번역',
+        success: true,
+        cacheTagId: 1,
+        cacheTag: { name: DEFAULT_CACHE_TAG },
+      })
+      .mockResolvedValueOnce(null);
+    client.translation.upsert.mockResolvedValue({
+      id: 22,
+      source: 'new-source',
+      target: '새 실패 번역',
+      success: false,
+      cacheTagId: 1,
+      cacheTag: { name: DEFAULT_CACHE_TAG },
+    });
+
+    await service.saveManyTranslations(
+      new Map([
+        ['cached-source', '실패 번역문 1'],
+        ['new-source', '새 실패 번역'],
+      ]),
+      false,
+      'test-model',
+      DEFAULT_CACHE_TAG,
+      'placeholder_mismatch'
+    );
+
+    expect(client.translation.upsert).toHaveBeenCalledTimes(1);
+    expect(client.translationHistory.create).toHaveBeenNthCalledWith(1, {
+      data: {
+        translationId: 21,
+        source: 'cached-source',
+        target: '실패 번역문 1',
+        success: false,
+        error: 'placeholder_mismatch',
+        model: 'test-model',
+        cacheTagId: 1,
+      },
+    });
+    expect(client.translationHistory.create).toHaveBeenNthCalledWith(2, {
+      data: {
+        translationId: 22,
+        source: 'new-source',
+        target: '새 실패 번역',
+        success: false,
+        error: 'placeholder_mismatch',
+        model: 'test-model',
+        cacheTagId: 1,
+      },
+    });
+  });
+});

--- a/apps/backend/src/nest/cache/loader/translation-loader/translation-loader.service.ts
+++ b/apps/backend/src/nest/cache/loader/translation-loader/translation-loader.service.ts
@@ -340,25 +340,12 @@ export class TranslationLoaderService {
         transactionContext,
         async (client, schedule) => {
           const cacheTag = await this.ensureCacheTag(cacheTagName, client);
-          const translation = await client.translation.upsert({
-            where: {
-              source_cacheTagId: {
-                source,
-                cacheTagId: cacheTag.id,
-              },
-            },
-            update: {
-              target,
-              success,
-              lastAccessedAt: new Date(),
-            },
-            create: {
-              source,
-              target,
-              success,
-              cacheTagId: cacheTag.id,
-            },
-            include: { cacheTag: true },
+          const translation = await this.upsertOrReuseTranslation({
+            client,
+            source,
+            target,
+            success,
+            cacheTagId: cacheTag.id,
           });
 
           await client.translationHistory.create({
@@ -402,25 +389,12 @@ export class TranslationLoaderService {
           const cacheTag = await this.ensureCacheTag(cacheTagName, client);
 
           for (const [source, target] of translations.entries()) {
-            const translation = await client.translation.upsert({
-              where: {
-                source_cacheTagId: {
-                  source,
-                  cacheTagId: cacheTag.id,
-                },
-              },
-              update: {
-                target,
-                success,
-                lastAccessedAt: new Date(),
-              },
-              create: {
-                source,
-                target,
-                success,
-                cacheTagId: cacheTag.id,
-              },
-              include: { cacheTag: true },
+            const translation = await this.upsertOrReuseTranslation({
+              client,
+              source,
+              target,
+              success,
+              cacheTagId: cacheTag.id,
             });
 
             await client.translationHistory.create({
@@ -591,6 +565,56 @@ export class TranslationLoaderService {
       where: { name: normalizedName },
       update: {},
       create: { name: normalizedName },
+    });
+  }
+
+  private async upsertOrReuseTranslation({
+    client,
+    source,
+    target,
+    success,
+    cacheTagId,
+  }: {
+    client: Prisma.TransactionClient;
+    source: string;
+    target: string;
+    success: boolean;
+    cacheTagId: number;
+  }) {
+    const existingTranslation = await client.translation.findUnique({
+      where: {
+        source_cacheTagId: {
+          source,
+          cacheTagId,
+        },
+      },
+      include: { cacheTag: true },
+    });
+
+    // 기존 성공 캐시는 유지하고, strict mismatch 실패는 이력만 추가합니다.
+    if (existingTranslation && existingTranslation.success && !success) {
+      return existingTranslation;
+    }
+
+    return client.translation.upsert({
+      where: {
+        source_cacheTagId: {
+          source,
+          cacheTagId,
+        },
+      },
+      update: {
+        target,
+        success,
+        lastAccessedAt: new Date(),
+      },
+      create: {
+        source,
+        target,
+        success,
+        cacheTagId,
+      },
+      include: { cacheTag: true },
     });
   }
 

--- a/apps/backend/src/nest/cache/loader/translation-loader/translation-loader.service.ts
+++ b/apps/backend/src/nest/cache/loader/translation-loader/translation-loader.service.ts
@@ -96,7 +96,7 @@ export class TranslationLoaderService {
       }
 
       const translations = await this.prisma.translation.findMany({
-        where: { OR: conditions },
+        where: { OR: conditions, success: true },
         include: { cacheTag: true },
       });
 
@@ -330,6 +330,7 @@ export class TranslationLoaderService {
     success: boolean = true,
     modelName: string = 'unknown',
     cacheTagName: string = DEFAULT_CACHE_TAG,
+    error: string | null = null,
     transactionClient?: Prisma.TransactionClient,
     transactionContext?: TransactionContext
   ): Promise<void> {
@@ -366,6 +367,7 @@ export class TranslationLoaderService {
               source,
               target,
               success,
+              error,
               model: modelName,
               cacheTagId: cacheTag.id,
             },
@@ -384,6 +386,7 @@ export class TranslationLoaderService {
     success: boolean = true,
     modelName: string = 'unknown',
     cacheTagName: string = DEFAULT_CACHE_TAG,
+    error: string | null = null,
     transactionClient?: Prisma.TransactionClient,
     transactionContext?: TransactionContext
   ): Promise<void> {
@@ -426,6 +429,7 @@ export class TranslationLoaderService {
                 source,
                 target,
                 success,
+                error,
                 model: modelName,
                 cacheTagId: cacheTag.id,
               },
@@ -469,6 +473,7 @@ export class TranslationLoaderService {
             where: { id },
             data: {
               target: newTarget,
+              success: true,
               lastAccessedAt: new Date(),
             },
             include: { cacheTag: true },


### PR DESCRIPTION
## 요약
- placeholder mismatch가 발생한 항목을 success=false 상태의 실패 캐시/이력으로 즉시 기록하도록 변경했습니다.
- 실패 레코드는 이후 자동 캐시 히트로 재사용되지 않도록 성공 캐시 조회를 success=true 항목만 보게 조정했습니다.
- 캐시에서 수동 수정하면 success=true로 복구되어 다시 정상 캐시로 동작하도록 보정했습니다.
- 실패 이력에 error=placeholder_mismatch를 함께 남기고, 기본 태그 미지정 시에도 메모리 캐시 키 무효화 규칙이 성공 경로와 일치하도록 정리했습니다.

## 테스트
- yarn workspace @apps/backend test --runTestsByPath /home/brain-offloaded/vscode/formatted-docs-ai-translator/apps/backend/src/nest/ai/services/__tests__/text-batch-translation.service.test.ts
- yarn workspace @apps/backend test --runTestsByPath /home/brain-offloaded/vscode/formatted-docs-ai-translator/apps/backend/src/nest/cache/cache-manager/services/__tests__/cache-manager.service.spec.ts
- yarn workspace @apps/backend lint
- yarn workspace @apps/backend build
