### PR TITLE
터보 빌드 산출물 캐시 경로를 분리

### DIFF
--- a/apps/frontend/webpack.config.js
+++ b/apps/frontend/webpack.config.js
@@ -36,7 +36,7 @@ const baseResolve = {
 
 const outputPath = path.resolve(__dirname, '../../dist');
 
-const createConfig = ({ name, target, entry, resolve: extraResolve = {} }) => ({
+const createConfig = ({ name, target, entry, resolve: extraResolve = {}, output: extraOutput = {} }) => ({
   name,
   mode,
   target,
@@ -52,6 +52,7 @@ const createConfig = ({ name, target, entry, resolve: extraResolve = {} }) => ({
   output: {
     filename: `${name}.js`,
     path: outputPath,
+    ...extraOutput,
   },
 });
 
@@ -59,6 +60,9 @@ const rendererConfig = createConfig({
   name: 'renderer',
   target: 'web',
   entry: './src/renderer.tsx',
+  output: {
+    chunkFilename: 'apps/frontend/chunks/[name].[contenthash].js',
+  },
   resolve: {
     mainFields: ['browser', 'module', 'main'],
     conditionNames: ['browser', 'import', 'module', 'default'],

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,35 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", "../../dist/**"]
+      "outputs": []
+    },
+    "@apps/common#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "@apps/backend#build": {
+      "dependsOn": ["^build"],
+      "outputs": [
+        "../../dist/main.js",
+        "../../dist/main.js.map",
+        "../../dist/main.d.ts",
+        "../../dist/main.d.ts.map",
+        "../../dist/env.js",
+        "../../dist/env.js.map",
+        "../../dist/env.d.ts",
+        "../../dist/env.d.ts.map",
+        "../../dist/nest/**",
+        "../../dist/tsconfig.backend.tsbuildinfo"
+      ]
+    },
+    "@apps/frontend#build": {
+      "dependsOn": ["^build"],
+      "outputs": [
+        "../../dist/preload.js",
+        "../../dist/renderer.js",
+        "../../dist/apps/frontend/**",
+        "../../dist/tsconfig.frontend.tsbuildinfo"
+      ]
     },
     "watch": {
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -4,23 +4,13 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": []
-    },
-    "@apps/common#build": {
-      "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
     "@apps/backend#build": {
       "dependsOn": ["^build"],
       "outputs": [
-        "../../dist/main.js",
-        "../../dist/main.js.map",
-        "../../dist/main.d.ts",
-        "../../dist/main.d.ts.map",
-        "../../dist/env.js",
-        "../../dist/env.js.map",
-        "../../dist/env.d.ts",
-        "../../dist/env.d.ts.map",
+        "../../dist/main.*",
+        "../../dist/env.*",
         "../../dist/nest/**",
         "../../dist/tsconfig.backend.tsbuildinfo"
       ]
@@ -28,8 +18,8 @@
     "@apps/frontend#build": {
       "dependsOn": ["^build"],
       "outputs": [
-        "../../dist/preload.js",
-        "../../dist/renderer.js",
+        "../../dist/preload.*",
+        "../../dist/renderer.*",
         "../../dist/apps/frontend/**",
         "../../dist/tsconfig.frontend.tsbuildinfo"
       ]


### PR DESCRIPTION
## 요약
- Turbo build output을 workspace별 실제 산출물 경로로 분리했습니다
- backend/frontend/common이 공유 dist 전체를 동시에 output으로 선언하던 구성을 제거했습니다
- yarn dev 재실행 시 stale dist가 남을 수 있는 원인을 줄였습니다

## 테스트
- yarn clean
- yarn build
- yarn build