### PR TITLE
[codex] 터보 캐시 정리와 패키징 앱 파일 파싱 정체 완화

### DIFF
--- a/apps/backend/src/nest/common/common.ipc.handler.ts
+++ b/apps/backend/src/nest/common/common.ipc.handler.ts
@@ -6,6 +6,7 @@ import { IpcChannel } from '@apps/common/dist/ipc/ipc-channel';
 import { errorToString } from '@/nest/utils/error-stringify';
 import { InvokeFunctionRequest, InvokeFunctionResponse } from '@apps/common/dist/types/electron';
 import * as path from 'path';
+import * as fs from 'fs/promises';
 import { OpenAdvancedViewerResponseDto } from '@apps/common/dist/ipc/dto/response/open-advanced-viewer-response.dto';
 import { AdvancedViewerLoadZipResponseDto } from '@apps/common/dist/ipc/dto/response/advanced-viewer-load-zip-response.dto';
 import { AdvancedViewerLoadZipRequestDto } from '@apps/common/dist/ipc/dto/request/advanced-viewer-load-zip-request.dto';
@@ -60,6 +61,23 @@ export class CommonIpcHandler extends IpcHandler {
       return { success: true, message: '외부 URL 열기 성공' };
     } catch (error) {
       this.logger.error('외부 URL 열기 실패:', { url, error: errorToString(error) });
+      return { success: false, message: errorToString(error) };
+    }
+  }
+
+  @HandleIpc(IpcChannel.ReadTextFile)
+  async readTextFile(
+    _event: Electron.IpcMainInvokeEvent,
+    { path: filePath }: InvokeFunctionRequest<IpcChannel.ReadTextFile>
+  ): Promise<InvokeFunctionResponse<IpcChannel.ReadTextFile>> {
+    try {
+      const content = await fs.readFile(filePath, 'utf8');
+      return { success: true, content };
+    } catch (error) {
+      this.logger.error('텍스트 파일 읽기 실패:', {
+        filePath,
+        error: errorToString(error),
+      });
       return { success: false, message: errorToString(error) };
     }
   }
@@ -151,7 +169,6 @@ export class CommonIpcHandler extends IpcHandler {
       let buffer: Buffer | undefined;
       // 1) 경로가 오면 디스크에서 직접 읽기 (최소 IPC 페이로드)
       if (zipPath) {
-        const fs = await import('fs/promises');
         buffer = await fs.readFile(zipPath);
         if (!name) name = path.basename(zipPath);
       } else if (zipBuffer) {

--- a/apps/common/src/ipc/ipc-channel.ts
+++ b/apps/common/src/ipc/ipc-channel.ts
@@ -1,6 +1,7 @@
 export enum IpcChannel {
   // 통합 채널 - 파일과 문자열을 함께 처리
   OpenExternalUrl = 'open-external-url',
+  ReadTextFile = 'read-text-file',
 
   // Advanced Image Viewer
   OpenAdvancedImageViewer = 'open-advanced-image-viewer',

--- a/apps/common/src/ipc/ipc.types.ts
+++ b/apps/common/src/ipc/ipc.types.ts
@@ -12,6 +12,14 @@ export interface OpenExternalUrlRequest {
 
 export interface OpenExternalUrlResponse extends BaseIpcResponse {}
 
+export interface ReadTextFileRequest {
+  path: string;
+}
+
+export interface ReadTextFileResponse extends BaseIpcResponse {
+  content?: string;
+}
+
 export interface OpenAdvancedViewerRequest {}
 
 export interface OpenAdvancedViewerResponse extends BaseIpcResponse {
@@ -38,6 +46,10 @@ export type IpcRequestResponseMap = {
   [IpcChannel.OpenExternalUrl]: {
     Request: OpenExternalUrlRequest;
     Response: OpenExternalUrlResponse;
+  };
+  [IpcChannel.ReadTextFile]: {
+    Request: ReadTextFileRequest;
+    Response: ReadTextFileResponse;
   };
   [IpcChannel.OpenAdvancedImageViewer]: {
     Request: OpenAdvancedViewerRequest;

--- a/apps/frontend/src/react/stores/translation-store.ts
+++ b/apps/frontend/src/react/stores/translation-store.ts
@@ -61,6 +61,20 @@ export type TranslationStore = TranslationStoreState & TranslationStoreActions;
 const applySetStateAction = <T>(current: T, updater: SetStateAction<T>): T =>
   typeof updater === 'function' ? (updater as (prev: T) => T)(current) : updater;
 
+const shallowEqualObject = <T extends object>(left: T, right: T): boolean => {
+  if (left === right) {
+    return true;
+  }
+
+  const leftKeys = Object.keys(left) as Array<keyof T>;
+  const rightKeys = Object.keys(right) as Array<keyof T>;
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+
+  return leftKeys.every((key) => left[key] === right[key]);
+};
+
 export const createTranslationStore = (
   initialState?: Partial<TranslationStoreState>
 ): StoreApi<TranslationStore> =>
@@ -84,9 +98,16 @@ export const createTranslationStore = (
       })),
     resetResultState: () => set({ resultState: createInitialResultState() }),
     setUIState: (updater) =>
-      set((state) => ({
-        uiState: applySetStateAction(state.uiState, updater),
-      })),
+      set((state) => {
+        const nextUIState = applySetStateAction(state.uiState, updater);
+        if (shallowEqualObject(state.uiState, nextUIState)) {
+          return state;
+        }
+
+        return {
+          uiState: nextUIState,
+        };
+      }),
     resetUIState: () => set({ uiState: createInitialUIState() }),
     setIsConfigValid: (isValid) => set({ isConfigValid: isValid }),
   }));

--- a/apps/frontend/src/react/unified/parser/utils/extract-single-text.ts
+++ b/apps/frontend/src/react/unified/parser/utils/extract-single-text.ts
@@ -2,11 +2,22 @@
 // - Returns '' for empty content
 // - Throws if unsupported type
 import { TranslationInput } from '../../domain/translation-input';
+import { IpcChannel } from '@apps/common/dist/ipc/ipc-channel';
+import { safeIpcInvoke } from '@/react/ipc/safeInvoke';
+import { getElectronFilePath, readFileAsText } from '@/react/utils/fileUtils';
 
 export async function extractSingleText(input: TranslationInput): Promise<string> {
   if (typeof input.content === 'string') return input.content.trim();
   if (input.content instanceof File) {
-    const text = await input.content.text();
+    const filePath = getElectronFilePath(input.content);
+    if (filePath) {
+      const { data } = await safeIpcInvoke(IpcChannel.ReadTextFile, { path: filePath });
+      if (data?.success && typeof data.content === 'string') {
+        return data.content.trim();
+      }
+    }
+
+    const text = await readFileAsText(input.content);
     return text.trim();
   }
   throw new Error('지원하지 않는 입력 타입입니다.');

--- a/apps/frontend/src/react/utils/fileUtils.ts
+++ b/apps/frontend/src/react/utils/fileUtils.ts
@@ -15,6 +15,28 @@ export const readFileAsArrayBuffer = (file: File): Promise<ArrayBuffer> => {
   });
 };
 
+export const readFileAsText = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result);
+      } else {
+        reject(new Error('Failed to read file as text'));
+      }
+    };
+    reader.onerror = (error) => {
+      reject(error);
+    };
+    reader.readAsText(file);
+  });
+};
+
+export const getElectronFilePath = (file: File): string | undefined => {
+  const possiblePath = (file as File & { path?: unknown }).path;
+  return typeof possiblePath === 'string' && possiblePath.length > 0 ? possiblePath : undefined;
+};
+
 export const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
   let binary = '';
   const bytes = new Uint8Array(buffer);

--- a/apps/frontend/webpack.config.js
+++ b/apps/frontend/webpack.config.js
@@ -36,7 +36,7 @@ const baseResolve = {
 
 const outputPath = path.resolve(__dirname, '../../dist');
 
-const createConfig = ({ name, target, entry, resolve: extraResolve = {} }) => ({
+const createConfig = ({ name, target, entry, resolve: extraResolve = {}, output: extraOutput = {} }) => ({
   name,
   mode,
   target,
@@ -52,6 +52,7 @@ const createConfig = ({ name, target, entry, resolve: extraResolve = {} }) => ({
   output: {
     filename: `${name}.js`,
     path: outputPath,
+    ...extraOutput,
   },
 });
 
@@ -59,6 +60,9 @@ const rendererConfig = createConfig({
   name: 'renderer',
   target: 'web',
   entry: './src/renderer.tsx',
+  output: {
+    chunkFilename: 'apps/frontend/chunks/[name].[contenthash].js',
+  },
   resolve: {
     mainFields: ['browser', 'module', 'main'],
     conditionNames: ['browser', 'import', 'module', 'default'],

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,35 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", "../../dist/**"]
+      "outputs": []
+    },
+    "@apps/common#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "@apps/backend#build": {
+      "dependsOn": ["^build"],
+      "outputs": [
+        "../../dist/main.js",
+        "../../dist/main.js.map",
+        "../../dist/main.d.ts",
+        "../../dist/main.d.ts.map",
+        "../../dist/env.js",
+        "../../dist/env.js.map",
+        "../../dist/env.d.ts",
+        "../../dist/env.d.ts.map",
+        "../../dist/nest/**",
+        "../../dist/tsconfig.backend.tsbuildinfo"
+      ]
+    },
+    "@apps/frontend#build": {
+      "dependsOn": ["^build"],
+      "outputs": [
+        "../../dist/preload.js",
+        "../../dist/renderer.js",
+        "../../dist/apps/frontend/**",
+        "../../dist/tsconfig.frontend.tsbuildinfo"
+      ]
     },
     "watch": {
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -4,23 +4,13 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": []
-    },
-    "@apps/common#build": {
-      "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
     "@apps/backend#build": {
       "dependsOn": ["^build"],
       "outputs": [
-        "../../dist/main.js",
-        "../../dist/main.js.map",
-        "../../dist/main.d.ts",
-        "../../dist/main.d.ts.map",
-        "../../dist/env.js",
-        "../../dist/env.js.map",
-        "../../dist/env.d.ts",
-        "../../dist/env.d.ts.map",
+        "../../dist/main.*",
+        "../../dist/env.*",
         "../../dist/nest/**",
         "../../dist/tsconfig.backend.tsbuildinfo"
       ]
@@ -28,8 +18,8 @@
     "@apps/frontend#build": {
       "dependsOn": ["^build"],
       "outputs": [
-        "../../dist/preload.js",
-        "../../dist/renderer.js",
+        "../../dist/preload.*",
+        "../../dist/renderer.*",
         "../../dist/apps/frontend/**",
         "../../dist/tsconfig.frontend.tsbuildinfo"
       ]


### PR DESCRIPTION
## 변경 내용
- Turbo build output 선언을 워크스페이스별로 분리했습니다.
- 프론트엔드 webpack 청크 출력 경로와 Turbo output 패턴을 맞춰 캐시 추적 범위를 보강했습니다.
- 패키징된 앱에서 파일 파싱 단계가 간헐적으로 멈추는 문제를 완화하기 위해 텍스트 파일 읽기 경로를 보강했습니다.

## 원인
- 기존에는 텍스트 계열 파서가 `File.text()`에만 의존했습니다.
- 패키징된 Electron/Windows 환경에서 이 경로가 간헐적으로 회수되지 않으면 `parsing` 상태에서 작업이 끝나지 않을 수 있었습니다.
- 또한 Turbo output 선언이 실제 산출 파일 패턴과 완전히 맞지 않아 캐시 추적이 불안정할 여지가 있었습니다.

## 영향
- 패키징 앱에서 파일 파싱이 멈추는 간헐 증상을 줄일 수 있습니다.
- Turbo build 캐시가 실제 산출물 구조를 더 정확히 반영합니다.

## 검증
- `yarn build`
- `yarn lint`
