### PR TITLE
[codex] 영문 문서 세트를 확장

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,62 @@
+# Formatted Docs AI Translator
+
+AI를 이용한 형식 보존 문서 번역 도구입니다.
+
+영문 메인 문서는 [README.md](./README.md)에서 확인할 수 있습니다.
+
+## 라이선스
+
+이 프로젝트는 MIT 라이선스를 따릅니다. 자세한 내용은 [LICENSE](./LICENSE)를 참고하세요.
+
+---
+
+### 작성자의 말
+
+#### 1. 소박한 바람
+
+이 도구가 도움이 되셨다면 출처를 남기거나 주변에 알려주시면 감사하겠습니다. 물론 **필수는 아니며**, 개인적인 바람일 뿐입니다. 출처 표기 없이 사용하셔도 충분히 감사합니다.
+
+#### 2. 완전한 자유
+
+형식적으로는 MIT 라이선스를 적용했지만, 실제로는 라이선스 조항을 엄격하게 집행할 생각이 거의 없습니다.
+제 이름을 지우거나, 심지어 본인이 만들었다고 주장하셔도 괜찮습니다.
+
+**단 한 가지 부탁만 있습니다.** 본인이 만들었다고 주장한 뒤 오히려 원작자인 저에게 저작권 침해를 주장하는 일만 아니라면, 자유롭게 사용하셔도 됩니다.
+
+## 주요 기능
+
+- 텍스트, JSON, CSV, SRT, 이미지 등 다양한 형식 지원
+- 여러 파일을 한 번에 처리하는 일괄 번역
+- 번역 설정과 워크플로를 사용자가 직접 제어 가능
+
+## 개발 문서
+
+- **[영문 문서](./docs/en/index.md)**
+- **[한글 문서](./docs/ko/index.md)**
+
+### Codex 유지보수 워크플로
+
+이 저장소는 Codex를 단순 코드 생성기가 아니라 OSS 유지보수 보조 에이전트로 사용합니다.
+
+- 저장소 규칙은 `AGENTS.md`에 둡니다.
+- 프로젝트 로컬 Codex 기본값은 `.codex/config.toml`에 둡니다.
+- 반복 가능한 유지보수 절차는 `.agents/skills/oss-maintainer-codex`에 둡니다.
+
+주요 사용 사례는 다음과 같습니다.
+
+- PR 설명과 검증 절차 정리
+- 개발자 문서와 Codex 운영 규칙 동기화
+- 릴리스 전 `yarn lint` / `yarn test` / `yarn build` 검증
+- Electron, Prisma, 번역 캐시를 건드리는 변경의 범위 축소
+
+### 로컬 개발
+
+- `yarn dev`: 전체 워크스페이스를 빌드한 뒤 Electron 앱을 실행합니다.
+- `yarn dev:watch`: 개발 중 변경 사항을 감지하며 다시 빌드합니다.
+
+### 데이터베이스 (Prisma)
+
+- Prisma 스키마: `prisma/schema.prisma`
+- DB 스키마 동기화: `yarn exec prisma db pull`
+- Prisma Client 재생성: `yarn exec prisma generate`
+- Prisma Studio 실행: `yarn prisma:studio`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An AI-powered translation tool for formatted documents.
 
-Korean documentation is available under [docs/ko](./docs/ko/index.md).
+Korean readers can use [README.ko.md](./README.ko.md) and [docs/ko](./docs/ko/index.md).
 
 ## License
 

--- a/docs/en/PACKAGING.md
+++ b/docs/en/PACKAGING.md
@@ -1,0 +1,154 @@
+# Electron Packaging Optimization Guide
+
+## Overview
+
+This project uses an optimized build and packaging setup to reduce Electron packaging time dramatically.
+
+**Measured improvements**
+- Before: about 2 minutes 20 seconds
+- After optimization, first run: 33 seconds (76% reduction)
+- After optimization, cached run: 20 seconds (86% reduction)
+
+## Commands
+
+### Fast local packaging
+
+```bash
+yarn package:linux
+yarn package:win
+```
+
+### Distribution packaging
+
+```bash
+yarn package:linux:dist
+yarn package:win:dist
+```
+
+## Optimization Techniques
+
+### 1. Automatic dependency sync
+
+**Problem:** in a Yarn workspace, `electron-builder` only recognizes dependencies declared in the root `package.json`.
+
+**Solution:** automatically sync runtime dependencies from `apps/backend/package.json` into the root packaging context through `scripts/prepare-package-optimized.mjs`.
+
+That means new runtime packages only need to be added in `apps/backend/package.json`.
+
+### 2. Selective `node_modules` copying
+
+Optimizations include:
+
+- fast copying with `rsync`
+- excluding dev dependencies such as ESLint, Prettier, and TypeScript
+- copying only the required production footprint
+
+Excluded package groups include:
+
+- `.cache`, `.bin`
+- `turbo`, `electron`, `electron-builder`
+- `eslint*`, `prettier`, `typescript`
+- `jest`, `@jest`, `nodemon`, `concurrently`
+- `@nestjs/cli`, `@nestjs/testing`
+- `webpack*`, `@babel`
+
+### 3. Timestamp-based caching
+
+How it works:
+
+- if staging `node_modules` is newer than the root copy, the copy step is skipped
+- first run performs the copy
+- later runs reuse the cache
+
+Cache invalidation happens when:
+
+- `yarn install` runs
+- `node_modules` changes
+
+### 4. Build setting optimization
+
+```json
+{
+  "npmRebuild": false,
+  "nodeGypRebuild": false,
+  "buildDependenciesFromSource": false,
+  "asar": {
+    "smartUnpack": false
+  }
+}
+```
+
+### 5. Separate local and distribution packaging
+
+**Local (`--dir`)**
+- skips ZIP compression
+- can run directly from `release/linux-unpacked/`
+
+**Distribution**
+- creates ZIP or installer outputs
+- intended for CI/CD and releases
+
+## Directory Layout
+
+```text
+apps/
+  backend/
+    app/
+      dist/
+      node_modules/
+      package.json
+      index.html
+release/
+  linux-unpacked/
+  formatted-docs-ai-translator-0.1.1.zip
+```
+
+## Troubleshooting
+
+### If the `node_modules` cache is the problem
+
+```bash
+rm -rf apps/backend/app
+yarn package:linux
+```
+
+### If dependencies do not appear correctly
+
+```bash
+cat apps/backend/package.json | grep "new-package"
+rm -rf apps/backend/app
+yarn package:linux
+```
+
+### If packaging fails
+
+```bash
+yarn clean
+rm -rf apps/backend/app release
+yarn build
+yarn package:linux
+```
+
+## Recommended CI/CD Setup
+
+```yaml
+- name: Package Application
+  run: yarn package:linux:dist
+
+- name: Cache Staging
+  uses: actions/cache@v3
+  with:
+    path: apps/backend/app/node_modules
+    key: staging-node-modules-${{ hashFiles('yarn.lock') }}
+```
+
+## Possible Future Improvements
+
+1. **pnpm**: use `nodeLinker: pnpm` to reduce disk usage through symlinks
+2. **esbuild bundling**: reduce `dist/` size further
+3. **Prebuilt native modules**: reduce rebuild time for packages such as `better-sqlite3`
+
+## References
+
+- Electron Builder: https://www.electron.build/
+- Yarn Workspaces: https://yarnpkg.com/features/workspaces

--- a/docs/en/adding-frontend.md
+++ b/docs/en/adding-frontend.md
@@ -1,0 +1,127 @@
+# Frontend Integration Guide (Unified Architecture)
+
+This document explains how to integrate a new translation type into the frontend after implementing the required `IParser` and `IApplier` described in [`adding-parser.md`](./adding-parser.md).
+
+## Prerequisites
+
+- The parser and applier for the new type already exist under `src/react/unified/parser/` and `src/react/unified/applier/`.
+- If needed, a custom `ITranslator` exists under `src/react/unified/translator/`. Most text-based formats reuse `TextArrayTranslator`.
+
+## Key Components
+
+The frontend uses a **factory-based architecture** to inject type-specific UI and logic.
+
+- **`translationStrategyFactory`** (`src/react/factories/translation-strategy-factory.ts`)
+  - builds the `parser`, `translator`, and `applier` combination for a `TranslationType`
+  - is injected into [`TranslatorEngine`](src/react/unified/engine/translator-engine.ts)
+- **`TranslatorFactory`** (`src/react/factories/TranslatorFactory.tsx`)
+  - renders the translator UI from definitions in [`src/react/config/translation-configs/`](src/react/config/translation-configs/)
+- **`ParseOptionsFactory`** (`src/react/factories/ParseOptionsFactory.tsx`)
+  - builds the parser options panel from the same config definitions
+
+## Integration Steps
+
+### 1. Extend `TranslationType`
+
+Add the new type to `src/react/contexts/translation/types.ts`.
+
+```ts
+export enum TranslationType {
+  Text = 'text',
+  Json = 'json',
+  Csv = 'csv',
+  Subtitle = 'subtitle',
+  Image = 'image',
+  Yaml = 'yaml',
+}
+```
+
+If needed, update `src/react/constants/TranslationTypeMapping.ts` so the dropdown label is correct.
+
+### 2. Register the combination in `translationStrategyFactory`
+
+Add the imports and the `switch` branch in `src/react/factories/translation-strategy-factory.ts`.
+
+```ts
+import { YamlParser } from '../unified/parser/yaml-parser';
+import { YamlApplier } from '../unified/applier/yaml-applier';
+import { TextArrayTranslator } from '../unified/translator/text-array-translator';
+
+case TranslationType.Yaml:
+  return {
+    parser: new YamlParser(),
+    translator: new TextArrayTranslator(),
+    applier: new YamlApplier(),
+  };
+```
+
+Formats like image translation may need a specialized translator such as `ImageTranslator`.
+
+### 3. Define the translation UI config
+
+Create a config file under `src/react/config/translation-configs/`.
+
+```ts
+import { TranslationConfigDefinition } from '@/react/types/translation-config-types';
+import { TranslationType } from '@/react/contexts/TranslationContext';
+import { OptionType } from '@/react/components/options/DynamicOptions';
+import { BaseParseOptionsDto } from '@/react/unified/domain/options/base-parse-options.dto';
+
+export const yamlConfig: TranslationConfigDefinition<BaseParseOptionsDto> = {
+  type: TranslationType.Yaml,
+  label: 'YAML Translation',
+  translator: {
+    inputLabel: 'YAML Input:',
+    inputPlaceholder: 'Paste YAML content or attach a file.',
+    fileExtension: '.yaml,.yml',
+    fileLabel: 'YAML File',
+    ipc: {
+      parse: null,
+      apply: null,
+    },
+  },
+  parser: {
+    options: {
+      label: 'YAML Parser Options',
+      optionItems: [
+        {
+          key: 'preserveComments',
+          label: 'Preserve comments',
+          type: OptionType.BOOLEAN,
+          description: 'Keep comments after translation.',
+        },
+      ],
+    },
+  },
+};
+```
+
+- The `translator` block controls labels, placeholders, and file picker UI.
+- `parser.options.optionItems` defines extra UI fields using the `OptionItem` contract from `DynamicOptions`.
+
+### 4. Export the config from the index
+
+Register the config in `src/react/config/translation-configs/index.ts`.
+
+```ts
+import { yamlConfig } from './yaml.config';
+
+export const translationConfigs = [
+  jsonConfig,
+  csvConfig,
+  textConfig,
+  subtitleConfig,
+  imageConfig,
+  yamlConfig,
+];
+```
+
+### 5. Verify integration with existing UI
+
+- Check that `TranslatorFactory.getConfig` and `ParseOptionsFactory.getConfig` build the expected translator and options panel.
+- For file-based types, confirm that `BaseTranslator` passes `isFile: true` in parser options.
+- If the new type needs advanced prompt presets, update `PromptPresetType` and related hooks such as `usePromptPresetLoader`.
+
+## Wrap-up
+
+After these steps, the new translation type appears in the `TranslateView` dropdown and reuses the same parse -> translate -> apply pipeline through `TranslatorEngine`. Special cases can still add their own UI layers on top, similar to image translation.

--- a/docs/en/adding-image-translation.md
+++ b/docs/en/adding-image-translation.md
@@ -1,0 +1,105 @@
+# Image Translation Extension Guide (Unified Architecture)
+
+This document explains how image translation works on top of the Unified Architecture and highlights the places to inspect when extending the related code.
+
+## 1. Data Flow Overview
+
+Image translation still follows **Parse -> Translate -> Apply**, but it includes OCR and post-processing, so it works with multiple `TranslationUnit` values.
+
+1. **Input collection**: when a user uploads images in the `ImageTranslator` component, `BaseTranslator` configures file-based parser options.
+2. **Parsing (`ImageParser`)**: [`src/react/unified/parser/image-parser.ts`](src/react/unified/parser/image-parser.ts) converts the file into a Base64 string and file name, then produces a single `TranslationUnit`. OCR does not happen here.
+3. **Translate (`ImageTranslator`)**: [`src/react/unified/translator/image-translator.ts`](src/react/unified/translator/image-translator.ts) sends that unit to `IpcChannel.TranslateImage`.
+   - it calls the Nest backend through `ipcClient.invoke`
+   - once the backend returns OCR and translated blocks, the translator rebuilds them as separate `TranslationUnit` items
+4. **Apply (`ImageApplier`)**: [`src/react/unified/applier/image-applier.ts`](src/react/unified/applier/image-applier.ts) overlays translated text on the image and returns a `TranslationOutput` that includes originals, translated images, and intermediate JSON
+5. **Aggregate and render**: the `useTranslator` hook merges output from multiple files and generates summary data. The UI then exposes statistics cards, ZIP download, and entry points into the advanced viewer.
+
+## 2. Core Code Locations
+
+### 2.1 `translationStrategyFactory`
+
+The image translation strategy lives in `src/react/factories/translation-strategy-factory.ts`.
+
+```ts
+case TranslationType.Image:
+  return {
+    parser: new ImageParser(),
+    translator: new ImageTranslator(),
+    applier: new ImageApplier(),
+  };
+```
+
+If you introduce another visual translation pipeline, add new parser/translator/applier implementations and route them from `TranslationType`.
+
+### 2.2 Parser (`ImageParser`)
+
+```ts
+export class ImageParser
+  implements IParser<TranslationInput<BaseParseOptionsDto>, TranslationUnit[]>
+{
+  async parse(input: TranslationInput<BaseParseOptionsDto>): Promise<TranslationUnit[]> {
+    const { base64, name } = await extractImageAsBase64(input);
+    if (!base64) return [];
+
+    return [
+      {
+        key: name,
+        source: base64,
+        target: '',
+      },
+    ];
+  }
+}
+```
+
+### 2.3 Translator (`ImageTranslator`)
+
+```ts
+const payload: TranslateImageRequestDto = {
+  requestId: crypto.randomUUID(),
+  aiSettings: config,
+  promptPresetContent: promptPresetContent || '',
+  sourceFilePath: sourceFilePath || '',
+  base64: unit.source,
+  cacheTag: config.cacheTag?.trim() ? config.cacheTag.trim() : DEFAULT_CACHE_TAG,
+};
+
+const response = (await ipcClient.invoke(
+  IpcChannel.TranslateImage,
+  payload
+)) as TranslateImageResponseDto;
+
+const blockUnits = translated.map((block, index) => ({
+  key: `${fileName}|${JSON.stringify(block.box_2d)}|${base64}`,
+  source: ocr[index]?.text ?? '',
+  target: block.text ?? '',
+}));
+```
+
+Each block carries both OCR text and translated text. The `key` also keeps the bounding box and original image reference so `ImageApplier` can perform the overlay step later.
+
+### 2.4 Applier (`ImageApplier`)
+
+- iterates through block units and applies overlays through `applyTextToImage`
+- prepares a `TranslationOutput` with `applied/`, `original/`, and `json/` paths for ZIP packaging
+- still returns original images and empty JSON structures when translated output is empty so that the UI remains stable
+
+## 3. Frontend UI Composition
+
+- **Translator component**: [`src/react/components/translators/ImageTranslator.tsx`](src/react/components/translators/ImageTranslator.tsx) extends `BaseTranslator` and handles prompt presets, file upload, and result panels.
+- **Prompt presets**: uses `PromptPresetType.IMAGE`; `usePromptPresetLoader` loads image-specific presets when `TranslationType.Image` is selected.
+- **Advanced image viewer**: the `useAdvancedImageViewer` hook opens `AdvancedImageViewer` and passes the ZIP for visual inspection of composites, OCR blocks, and translated blocks.
+
+## 4. Result Aggregation and Download Flow
+
+1. `useTranslator` adds file-level jobs to `TranslationJobManager`.
+2. After completion, `TranslationOutput.merge` combines them and stores report text, ZIP output, and single-file blobs in `TranslationContext`.
+3. `ImageTranslator` shows summary cards and only enables ZIP download or advanced viewer actions when at least one file succeeded.
+
+## 5. Extension Checklist
+
+- **Need a new IPC route?** Check whether `TranslateImage` is enough or whether Nest DTOs must be extended.
+- **Need more output artifacts?** Update the file list returned by `ImageApplier`.
+- **Need more prompt types?** Extend `PromptPresetType` and related config stores.
+
+Understanding this flow makes it much easier to extend the image translation pipeline safely or to add other visual translation types later.

--- a/docs/en/adding-parser.md
+++ b/docs/en/adding-parser.md
@@ -1,0 +1,179 @@
+# Adding a New Parser (Unified Architecture)
+
+## Introduction
+
+This guide explains how to add support for a new file format by implementing a parser and an applier. The current frontend uses a **Unified Architecture** in which parsing, translation, and apply logic are composed in the Electron renderer (React). Backend IPC channels are only used for shared translation requests such as `TranslateTextArray` and `TranslateImage`, so most changes for a new format happen in the frontend.
+
+Core concepts:
+
+- **`IParser`**: converts input into `TranslationUnit[]`
+- **`IApplier`**: applies translated units back into the original structure and produces `TranslationOutput`
+- **`ITranslator`**: sends parser output to the AI translator. Text-based formats usually reuse `TextArrayTranslator`; special cases can add a custom implementation.
+- **`TranslationStrategy`**: the parser/translator/applier combination built by [`translationStrategyFactory`](src/react/factories/translation-strategy-factory.ts)
+
+> `TranslationInput.content` is always a single string or a single `File`. When users upload multiple files, [`TranslationJobManager`](src/react/services/job-manager/TranslationJobManager.ts) creates one job per file. New parsers do not need to handle `File[]` directly.
+
+## Step 1: Define a parser options DTO (optional)
+
+If the new parser needs custom options, define a DTO:
+
+1. **Directory**: [`src/react/unified/domain/options/`](src/react/unified/domain/options/)
+2. **File**: `new-format-parser-options.dto.ts`
+3. **Implementation**: extend `BaseParseOptionsDto`
+
+```ts
+import { BaseParseOptionsDto } from './base-parse-options.dto';
+
+export class NewFormatParserOptionsDto extends BaseParseOptionsDto {
+  // Example custom options
+  // customDelimiter?: string;
+}
+```
+
+If no custom options are needed, reusing `BaseParseOptionsDto` is fine.
+
+## Step 2: Implement the parser (`IParser`)
+
+1. **Directory**: [`src/react/unified/parser/`](src/react/unified/parser/)
+2. **File**: `new-format-parser.ts`
+3. **Implementation**: provide `parse` and extract text from a string or single `File`
+
+```ts
+import { IParser } from './i-parser';
+import { TranslationInput } from '../domain/translation-input';
+import { TranslationUnit } from '../domain/translation-unit';
+import { NewFormatParserOptionsDto } from '../domain/options/new-format-parser-options.dto';
+
+export class NewFormatParser
+  implements IParser<TranslationInput<NewFormatParserOptionsDto>, TranslationUnit[]>
+{
+  async parse(input: TranslationInput<NewFormatParserOptionsDto>): Promise<TranslationUnit[]> {
+    const raw = await this.extractText(input.content);
+    const units: TranslationUnit[] = [];
+
+    raw.split('\n').forEach((line, index) => {
+      units.push({
+        key: `line_${index}`,
+        source: line,
+        target: '',
+      });
+    });
+
+    return units;
+  }
+
+  private async extractText(content: string | File): Promise<string> {
+    if (typeof content === 'string') return content;
+    return content.text();
+  }
+}
+```
+
+## Step 3: Implement the applier (`IApplier`)
+
+1. **Directory**: [`src/react/unified/applier/`](src/react/unified/applier/)
+2. **File**: `new-format-applier.ts`
+3. **Implementation**: rebuild the translated structure and return `TranslationOutput`
+
+```ts
+import { IApplier } from './i-applier';
+import { TranslationInput } from '../domain/translation-input';
+import { TranslationUnit } from '../domain/translation-unit';
+import { TranslationOutput } from '../domain/translation-output';
+import { NewFormatParserOptionsDto } from '../domain/options/new-format-parser-options.dto';
+
+export class NewFormatApplier
+  implements IApplier<TranslationInput<NewFormatParserOptionsDto>, TranslationUnit[], TranslationOutput>
+{
+  async apply(
+    originalInput: TranslationInput<NewFormatParserOptionsDto>,
+    translatedTexts: TranslationUnit[]
+  ): Promise<TranslationOutput> {
+    const original = await this.readOriginal(originalInput.content);
+    const map = new Map(translatedTexts.map((unit) => [unit.key, unit.target]));
+
+    const rebuilt = original
+      .split('\n')
+      .map((line, index) => map.get(`line_${index}`) ?? line)
+      .join('\n');
+
+    const fileName =
+      typeof originalInput.content === 'string'
+        ? 'translated.new-format'
+        : `${originalInput.content.name}.out`;
+
+    return new TranslationOutput([
+      {
+        name: fileName,
+        success: true,
+        result: rebuilt,
+      },
+    ]);
+  }
+
+  private async readOriginal(content: string | File): Promise<string> {
+    if (typeof content === 'string') return content;
+    return content.text();
+  }
+}
+```
+
+## Step 4: Register the translation strategy
+
+Update `TranslationType` and the strategy factory so the new combination can be used.
+
+1. **Add enum entry** in `src/react/contexts/translation/types.ts`
+2. **Add label** in `src/react/constants/TranslationTypeMapping.ts` if needed
+3. **Register the strategy** in `src/react/factories/translation-strategy-factory.ts`
+
+```ts
+import { NewFormatParser } from '../unified/parser/new-format-parser';
+import { NewFormatApplier } from '../unified/applier/new-format-applier';
+import { TextArrayTranslator } from '../unified/translator/text-array-translator';
+
+case TranslationType.NewFormat:
+  return {
+    parser: new NewFormatParser(),
+    translator: new TextArrayTranslator(),
+    applier: new NewFormatApplier(),
+  };
+```
+
+## Step 5: Wire it into the UI
+
+The frontend UI is rendered from definitions under [`src/react/config/translation-configs/`](src/react/config/translation-configs/). Add a config file for the new format.
+
+```ts
+import { TranslationConfigDefinition } from '@/react/types/translation-config-types';
+import { TranslationType } from '@/react/contexts/TranslationContext';
+import { NewFormatParserOptionsDto } from '@/react/unified/domain/options/new-format-parser-options.dto';
+
+export const newFormatConfig: TranslationConfigDefinition<NewFormatParserOptionsDto> = {
+  type: TranslationType.NewFormat,
+  label: 'New Format Translation',
+  translator: {
+    inputLabel: 'Input:',
+    inputPlaceholder: 'Paste content or upload a file.',
+    fileExtension: '.nf',
+    fileLabel: 'New Format File',
+    ipc: { parse: null, apply: null },
+  },
+  parser: {
+    options: {
+      label: 'New Format Parser Options',
+      optionItems: [],
+    },
+    dto: NewFormatParserOptionsDto,
+  },
+};
+```
+
+Then export it from `src/react/config/translation-configs/index.ts`.
+
+## Step 6: Test Checklist
+
+- Run the new translation type in `yarn dev` or `yarn dev:watch` and confirm that the input and options UI render correctly.
+- Execute translation through `useTranslator` and verify that ZIP or text output matches the expected structure.
+- For file input, confirm that `BaseTranslator` passes `parserOptions.isFile = true`.
+
+After these steps, the new format is fully integrated into the Unified Architecture pipeline.

--- a/docs/en/frontend-architecture.md
+++ b/docs/en/frontend-architecture.md
@@ -1,0 +1,78 @@
+# Frontend Architecture
+
+This document summarizes the frontend structure of Formatted Docs AI Translator. The current codebase is designed to support multiple translation types dynamically inside the Electron renderer (React), including text, JSON, CSV, subtitles, images, and more.
+
+## Core Principles
+
+1. **Unified translation pipeline**: every translation runs through `Parse -> Translate -> Apply`, and [`TranslatorEngine`](src/react/unified/engine/translator-engine.ts) executes a `TranslationStrategy` combination in order.
+2. **Config-driven UI generation**: translators and option panels are generated from the definitions in [`src/react/config/translation-configs/`](src/react/config/translation-configs/), so adding a new type usually requires only minimal UI changes.
+3. **Job-managed concurrency**: translation requests are queued by `TranslationJobManager`, while the `useTranslator` hook manages state updates and cancellation.
+
+## Directory Overview (`src/react`)
+
+- `unified/`
+  - `parser/`, `translator/`, `applier/`: implementations for each pipeline stage
+  - `engine/`: `TranslatorEngine` and related types
+  - `domain/`: shared models such as `TranslationInput`, `TranslationUnit`, and `TranslationOutput`
+- `config/translation-configs/`
+  - labels, input form options, and parser options for each translation type
+- `factories/`
+  - [`translation-strategy-factory.ts`](src/react/factories/translation-strategy-factory.ts): builds the parser/translator/applier combination for each `TranslationType`
+  - [`TranslatorFactory.tsx`](src/react/factories/TranslatorFactory.tsx): memoizes and renders config-based translator UIs
+  - [`ParseOptionsFactory.tsx`](src/react/factories/ParseOptionsFactory.tsx): builds parser option panels
+- `views/`
+  - `TranslateView/`: the main translation screen and related hooks
+  - `AdvancedImageViewer/`, `ImageViewerView/`: viewers for image translation results
+- `contexts/`
+  - [`TranslationContext.tsx`](src/react/contexts/TranslationContext.tsx): global translation state, job management, snackbar handling, and file state
+  - `translation/types.ts`: `TranslationType` and UI state types
+- `services/job-manager/`
+  - `TranslationJobManager.ts`, `job.ts`, `job-manager.types.ts`: concurrency management for translation jobs
+
+## Unified Core Flow
+
+1. **Parsing**
+   - An `IParser` converts the input (`string` or `File[]`) into `TranslationUnit[]`.
+   - Examples: `PlainTextParser`, `JsonParser`, `ImageParser`.
+2. **Translation**
+   - An `ITranslator` sends the units to the AI service.
+   - `TextArrayTranslator` calls `IpcChannel.TranslateTextArray` to translate a text array.
+   - `ImageTranslator` returns OCR and translation output in block units.
+3. **Apply**
+   - An `IApplier` reassembles the translated units into the original format.
+   - The result is returned as `TranslationOutput`, which can then be used as ZIP output or text/Blob output.
+
+## Factory-Based UI Composition
+
+- **`TranslatorFactory`**
+  - uses the `translator` options registered in `translation-configs` to build `BaseTranslator`
+  - can configure labels, file extensions, placeholders, and output formatting
+- **`ParseOptionsFactory`**
+  - uses the same configuration's `parser.options` to render `BaseParseOptions`
+  - the `OptionItem` array defines the dynamic form structure
+- **`useTranslatorFactories`**
+  - resolves the translator component, options component, and labels for the current `TranslationType` inside `TranslateView`
+
+## Job Management and State Flow
+
+1. `TranslationProvider` creates `TranslationJobManager` lazily through `useTranslationJobManager`. Concurrency is derived from `useConfigStore().requestsPerMinute`.
+2. The `useTranslator` hook calls `getJobManager()`, queues file or text input as jobs, and subscribes to `onProgress` and `onAllComplete` to update UI state such as `translationProgress`, `completed`, and `failed`.
+3. When jobs finish, `TranslationOutput.merge` aggregates the results and `TranslationContext` stores ZIP blobs, single-file blobs, and summary reports.
+4. `cancelTranslation()` calls `TranslationJobManager.cancel()`, moving all `PENDING` or `RUNNING` jobs to `CANCELLED`.
+
+## `TranslateView` Summary
+
+1. The user selects a translation type from the dropdown, which updates `translationType` in `TranslationContext`.
+2. `useTranslatorFactories` returns the matching translator and options components.
+3. When the user starts translation, `useTranslator` enqueues the input and updates progress and result state.
+4. After all jobs complete, `TranslationContext` stores the result and result components such as `ImageTranslator` render download and summary UI.
+
+## Extension Notes
+
+- When adding a new type, check `TranslationType`, `translation-strategy-factory`, `translation-configs`, and `TranslationTypeMapping` together.
+- If job behavior for multi-file translation needs to change, update `TranslationJobManager` or `useTranslationJobManager` for concurrency and retry policy changes.
+- If new IPC routes are introduced, update both the `ipcClient` wrapper and the Nest DTOs.
+
+## Known Issue
+
+- **Scattered business logic**: domain rules such as cache tag registration, translation result summarization, and ZIP downloads are spread across components and hooks. That makes backend API changes expensive because several files must be updated together. Centralizing those rules in shared services would reduce that coupling.

--- a/docs/en/how-to-release.md
+++ b/docs/en/how-to-release.md
@@ -1,0 +1,88 @@
+# Release Process Guide
+
+This document explains the GitHub Flow based release process for Formatted Docs AI Translator.
+
+## Branch Strategy
+
+The project uses the following strategy:
+
+- `main`: the deployable default branch
+- `feature/*`, `fix/*`, and similar branches: short-lived working branches
+
+Long-lived release branches such as `develop` or `release/*` are not used.
+
+## Release Procedure
+
+### 1. Prepare release changes and merge them into `main`
+
+Create a working branch from `main`, update the version and changelog, and merge the result back through a pull request.
+
+```bash
+# Sync main
+git checkout main
+git pull origin main
+
+# Create a working branch
+git checkout -b chore/release-v1.2.3
+
+# Update the version
+yarn version:set 1.2.3
+
+# Update CHANGELOG.md, then commit
+git add package.json CHANGELOG.md
+git commit -m "chore: release v1.2.3"
+git push origin chore/release-v1.2.3
+```
+
+Once the PR is created and CI passes, merge it into `main`.
+
+### 2. Publish the release tag
+
+Tags are created manually from the release commit on `main`.
+
+```bash
+git checkout main
+git pull origin main
+
+# Check whether the tag already exists
+git tag -l "v1.2.3"
+
+# Create and push the tag
+git tag -a v1.2.3 -m "Release v1.2.3"
+git push origin v1.2.3
+```
+
+### 3. Trigger GitHub Actions manually
+
+1. Open the repository's **Actions** tab
+2. Select the **Package (Windows ZIP)** workflow
+3. Click **Run workflow**
+4. Enter `v1.2.3` in the `release_tag` input and run it
+
+The workflow:
+
+- validates the tag format (`vX.Y.Z`)
+- verifies that the remote tag exists
+- builds the Windows ZIP from the tagged commit
+- creates a Draft Release automatically if one does not already exist
+- uploads the artifact to the release assets with `--clobber`
+
+### 4. Review the draft release and publish it
+
+1. Open **Releases** in the repository
+2. Find the draft release for `v1.2.3`
+3. Review the notes and attached files
+4. Click **Publish release**
+
+## Re-run Guide
+
+- Re-running the workflow with the same tag overwrites the assets because `--clobber` is used.
+- If the tag does not exist, the workflow fails. Run `git push origin vX.Y.Z` first.
+
+## Versioning Rules
+
+The project follows [Semantic Versioning](https://semver.org/):
+
+- **Major**: incompatible API changes
+- **Minor**: backward-compatible feature additions
+- **Patch**: backward-compatible bug fixes

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -4,24 +4,24 @@ This section documents the architecture, development workflow, and contributor g
 
 ## Getting Started
 
-- **[Release Process](../ko/how-to-release.md)**: How to prepare and ship a new release. English version pending.
-- **[Packaging Optimization Guide](../ko/PACKAGING.md)**: Notes on reducing Electron packaging time. An English version has not been added yet.
+- **[Release Process](./how-to-release.md)**: How to prepare and ship a new release.
+- **[Packaging Optimization Guide](./PACKAGING.md)**: Notes on reducing Electron packaging time.
 - **[Codex Configuration Guide](./codex.md)**: How this repository uses `AGENTS.md`, `.codex`, and repo-specific skills.
 
 ## Architecture
 
-- **[Frontend Architecture](../ko/frontend-architecture.md)**: React renderer structure and core design principles. English version pending.
-- **[Job Management System](../ko/job-management-system.md)**: Frontend job orchestration for concurrent translation. English version pending.
-- **[Unified Domain Models](../ko/unified-domain-models.md)**: Core domain objects used by the translation pipeline. English version pending.
-- **[IPC to REST Migration Roadmap](../ko/rest-migration-plan.md)**: Notes from the IPC-to-REST transition. English version pending.
+- **[Frontend Architecture](./frontend-architecture.md)**: React renderer structure and core design principles.
+- **[Job Management System](./job-management-system.md)**: Frontend job orchestration for concurrent translation.
+- **[Unified Domain Models](./unified-domain-models.md)**: Core domain objects used by the translation pipeline.
+- **[IPC to REST Migration Roadmap](./rest-migration-plan.md)**: Notes from the IPC-to-REST transition.
 
 ## Adding Features
 
-- **[Adding a New Parser](../ko/adding-parser.md)**: How to add a parser and applier for a new file format. English version pending.
-- **[Frontend Integration Guide](../ko/adding-frontend.md)**: How to connect a new translation type to the frontend. English version pending.
-- **[Image Translation Extension Guide](../ko/adding-image-translation.md)**: How image translation works and how to extend it. English version pending.
+- **[Adding a New Parser](./adding-parser.md)**: How to add a parser and applier for a new file format.
+- **[Frontend Integration Guide](./adding-frontend.md)**: How to connect a new translation type to the frontend.
+- **[Image Translation Extension Guide](./adding-image-translation.md)**: How image translation works and how to extend it.
 
 ## Other References
 
-- **[Language Metadata Guide](../ko/languages.md)**: How language metadata is organized. English version pending.
-- **[Local vLLM Server Guide](../ko/vllm-local-server.md)**: How to run and connect to an OpenAI-compatible local server. English version pending.
+- **[Language Metadata Guide](./languages.md)**: How language metadata is organized.
+- **[Local vLLM Server Guide](./vllm-local-server.md)**: How to run and connect to an OpenAI-compatible local server.

--- a/docs/en/job-management-system.md
+++ b/docs/en/job-management-system.md
@@ -1,0 +1,59 @@
+# Job Management System for Concurrent Translation
+
+## 1. Background
+
+Processing large files sequentially made translation too slow. To address that, the frontend introduces a lightweight job management layer that supports concurrency, cancellation, and progress tracking. The current implementation runs entirely in the renderer on top of React context and hooks, without requiring backend changes.
+
+## 2. Core Components
+
+### 2.1 Job Model (`src/react/services/job-manager/job.ts`)
+
+- `JobStatus` defines `PENDING`, `RUNNING`, `RETRYING`, `SUCCEEDED`, `FAILED`, and `CANCELLED`.
+- `Job<T>` includes `id`, `data`, `retryCount`, `result`, and `error`.
+- `data` is either a `File` or a string for text input.
+
+### 2.2 `TranslationJobManager` (`src/react/services/job-manager/TranslationJobManager.ts`)
+
+- **Queue and state management**: tracks jobs through an internal `Map` and queue array.
+- **Concurrency control**: runs up to `options.concurrency` workers at once. The default is 1 and can be updated at runtime through `updateConfig`.
+- **Events**: exposes `onProgress`, `onJobComplete`, and `onAllComplete`.
+  - `onProgress` computes total, completed, and failed jobs for UI updates.
+  - `onAllComplete` runs once when the queue is empty and resets worker references.
+- **Retry and cancellation**: the default retry count is 0. `cancel()` clears the queue and marks running jobs as `CANCELLED`.
+
+### 2.3 React Integration Hooks
+
+- **`useTranslationJobManager`** (`src/react/contexts/translation/useTranslationJobManager.ts`)
+  - used from `TranslationProvider`
+  - creates the JobManager lazily based on `concurrencyLimit`
+  - exposes `cancelTranslation`, `resetJobManager`, and related controls
+- **`TranslationContext`** (`src/react/contexts/TranslationContext.tsx`)
+  - provides `getJobManager`, `cancelTranslation`, `resetJobManager`
+  - also manages `isTranslating`, `uiState`, `resultState`, and related translation state
+- **`useTranslator`** (`src/react/hooks/useTranslator.ts`)
+  - acquires the JobManager, adds inputs as jobs, and registers listeners
+  - applies progress updates to UI state
+  - merges results through `TranslationOutput.merge` on completion
+  - records failed jobs as `FAILED` and includes their messages in the report
+
+## 3. Execution Flow
+
+1. When the user starts translation, `useTranslator` clears previous results and queues the new jobs.
+2. `TranslationJobManager.start(worker)` begins consuming jobs. The worker runs parse -> translate -> apply through `TranslatorEngine` and returns `TranslationOutput`.
+3. Each job updates to `SUCCEEDED` or `FAILED`, triggering events that refresh the UI and stores.
+4. After all jobs complete, `onAllComplete` prepares ZIP output, single-file output, and success/failure summaries.
+5. If the user clicks cancel, `cancelTranslation()` marks queued and running jobs as `CANCELLED` and immediately updates progress and `isTranslating`.
+
+## 4. Concurrency and Configuration
+
+- Concurrency is set in `TranslationProvider` from `useConfigStore().requestsPerMinute`, clamped between 1 and 5.
+- When settings change and a new translation starts, `useTranslationJobManager` updates the existing JobManager through `updateConfig`.
+- Retry counts can be tuned through `options.retries`, and backoff strategies can be added by extending `TranslationJobManager.processJob`.
+
+## 5. Extension Tips
+
+- **Finer-grained progress**: current progress is based on completed and failed jobs only. If unit-level progress is needed, wire `ProgressCallback` into the worker and include it in JobManager events.
+- **Weighted results**: if some jobs should contribute differently to progress or reporting, adjust `onProgress` or `TranslationOutput.merge`.
+- **Error handling**: use the `error` field on `FAILED` jobs to produce user-facing messages in components such as `TranslationError`.
+
+The current design provides concurrent translation, partial failure reporting, and instant cancellation entirely in the frontend, while allowing new translation types to reuse the same job pipeline.

--- a/docs/en/languages.md
+++ b/docs/en/languages.md
@@ -1,0 +1,43 @@
+# Language Metadata Guide
+
+## Overview
+
+- Languages used by the translation pipeline are defined only in `src/common/language.ts`.
+- The same enum set is shared between Nest and React, so additions and edits happen in one place.
+- Metadata (`languageMetadata`) keeps only multilingual labels and UI visibility (`supportsUI`).
+
+## Main Types and Constants
+
+| Name | Description |
+| --- | --- |
+| `Language` | Full language enum recognized by the app, including `Language.ANY` |
+| `SourceLanguage` | Enum used for source language selection, including `ANY` |
+| `TargetLanguage` | Enum used for translation target selection |
+| `languageMetadata` | Per-language metadata array with labels and `supportsUI` |
+| `sourceLanguages` / `targetLanguages` | Enum-based language lists |
+| `uiLanguages` | Languages available in the UI (`supportsUI === true`) |
+| `getLanguageLabel`, `getLanguageLabelByCode` | Convert IDs or code strings such as `ko` and `en` into labels |
+
+## Adding a Language
+
+1. Add a new entry to the `Language` enum.
+2. Add the matching label and `supportsUI` value to `LANGUAGE_DEFINITIONS`.
+3. If needed, add string detection helpers such as `isSpanish` and connect them through `isLanguage`.
+4. Check whether presets, caches, or other domain logic depend on the language set.
+
+## The Role of `ANY`
+
+- `Language.ANY` is used for detection mode or inputs that are not fixed to a single language.
+- It is not included in target translation language lists and is excluded from preset persistence.
+- In the UI it is presented as “Any Language / 모든 언어”.
+
+## Presets and Metadata
+
+- Example presets create an n×n matrix from `targetLanguages`.
+- When a language is added, updating metadata is enough for both UI and backend loops to expand automatically.
+- Prompt and settings screens combine `getLanguageLabel` and `uiLanguages` for display.
+
+## Cautions
+
+- Metadata array order becomes the default order in dropdowns.
+- When adding labels for a new language, update i18n resources under `src/react/locales/*.json` as well.

--- a/docs/en/rest-migration-plan.md
+++ b/docs/en/rest-migration-plan.md
@@ -1,0 +1,127 @@
+# IPC to REST Migration Roadmap
+
+## 1. Base Nest HTTP Application Setup
+
+- [x] Replace `NestFactory.createApplicationContext` with `NestFactory.create` in `bootstrap.ts` and run the HTTP server through `FastifyAdapter`.
+- [x] Register `ValidationPipe` globally with safe options such as `whitelist`, `transform`, and `forbidNonWhitelisted`.
+- [x] Configure `ClassSerializerInterceptor` and `SerializeOptions` globally to control response serialization.
+- [x] Confirm `class-transformer` and `class-validator` dependencies are present and keep the existing versions.
+- [x] Add Swagger and expose API docs at `/swagger`, generating the schema through `SwaggerModule.createDocument`.
+
+## 2. Swagger-Based Codegen Pipeline
+
+- [x] Implement `src/nest/create-swagger.ts` to bootstrap Nest and write Swagger JSON to disk.
+- [x] Add a script in `package.json` or `scripts/` to automate Swagger generation.
+- [x] Create a renderer-side codegen script that uses Swagger JSON as input and outputs generated clients under `src/react/api/generated`.
+- [x] Add a codegen tool configuration to generate type-safe clients.
+- [x] Prepare the Electron main process to import Swagger-based generated clients and use HTTP instead of IPC.
+- [x] Document the rule that generated Swagger models are the single source of truth for shared API types, replacing manual definitions in `src/common` or `src/types`.
+
+## 3. Module-by-Module IPC -> REST Migration Loop
+
+Each module follows the steps below. After each conversion, run `yarn build` and `yarn lint`, then commit the result.
+
+### 1. Identify the scope
+
+- Find the IPC channel (`ipc.channel.ts`) and handler (`ipc.handler.ts`) that will move.
+- Identify related DTOs, services, and utilities.
+
+### 2. Convert the server side
+
+- Move IPC handler logic into Nest controller methods and map DTOs with `@Body`, `@Query`, and `@Param`.
+- For numeric `@Param()` values, do not rely only on `enableImplicitConversion`; use `@Type(() => Number)` explicitly in DTO fields.
+- Define response serialization explicitly through `@SerializeOptions({ type: DTO })` and DTO decorators such as `@Expose` and `@Type`.
+- Keep service-layer calls but adapt them to HTTP response semantics.
+- Make every HTTP response DTO inherit from `BaseResponseDto`, not from IPC-only types.
+- Put every request and response shape into dedicated DTO files and annotate them fully for Swagger and runtime validation.
+- For nested objects, split them into DTO classes and annotate both `@Type` and Swagger metadata explicitly.
+- If a payload is too complex to model cleanly, split it into simpler REST endpoints instead of leaking `any` into the API contract.
+- Use `@ApiOkResponse` to expose response shapes in Swagger.
+- Remove stale manual types under `src/common` when Swagger-generated types should replace them.
+- Register the new controllers in the relevant Nest modules.
+
+### 3. Replace the client side
+
+- Run `yarn codegen` first so renderer code uses the newest generated client.
+- Replace IPC call sites with generated HTTP client calls.
+- In the frontend, use generated models under `src/react/api/generated/models` instead of manual types under `src/types`.
+- Remove obsolete IPC code after replacement.
+
+### 4. Validate and QA
+
+- Run the main Electron flows for the module and confirm HTTP behavior works end to end.
+- Run `yarn build` and `yarn lint`, and update tests if necessary.
+- Record QA results and move on to the next module.
+
+## Progress Checklist by IPC Function
+
+### Translation - image
+
+- [x] `translateImage`
+
+### Settings
+
+- [x] `getSetting`
+- [x] `updateSetting`
+- [x] `getAllSettings`
+- [x] `deleteSetting`
+
+### Logging
+
+- [x] `getLogs`
+- [x] `getLogDetail`
+- [x] `deleteLogs`
+- [x] `deleteAllLogs`
+
+### Translation prompt presets
+
+- [x] `getPromptPresets`
+- [x] `getPromptPresetDetail`
+- [x] `createPromptPreset`
+- [x] `updatePromptPreset`
+- [x] `deletePromptPreset`
+
+### Translator
+
+- [x] `translateTextArray`
+
+### Example presets
+
+- [x] `getExamplePresets`
+- [x] `getExamplePresetDetail`
+- [x] `loadExamplePreset`
+- [x] `createExamplePreset`
+- [x] `deleteExamplePreset`
+- [x] `updateExamplePreset`
+
+### Temporary workspace
+
+- [x] `cleanupTempWorkspace`
+
+### Cache / translation history
+
+- [x] `getTranslations`
+- [x] `getTranslationHistory`
+- [x] `updateTranslation`
+- [x] `updateTranslationCacheTag`
+- [x] `deleteTranslation`
+- [x] `deleteAllTranslations`
+- [x] `exportTranslations`
+- [x] `importTranslations`
+- [x] `getCacheTags`
+- [x] `deleteCacheTag`
+
+### Common Electron/system operations
+
+- [x] `openZipInAdvancedViewerDialog` - intentionally excluded from REST
+- [x] `openExternalUrl` - intentionally excluded from REST
+- [x] `openAdvancedViewer` - intentionally excluded from REST
+- [x] `advancedViewerLoadZip` - intentionally excluded from REST
+
+## 4. Shared Considerations
+
+- Keep functional behavior equivalent while removing the IPC path completely where migration applies.
+- Keep Swagger documents and generated clients consistent after every module conversion.
+- Since the Electron app talks only to localhost, keep security and auth settings minimal and scoped to the local scenario.
+- Commit changes module by module and describe scope and testing clearly in PRs.
+- After migration completes, remove remaining IPC-only files and configuration to simplify the codebase.

--- a/docs/en/unified-domain-models.md
+++ b/docs/en/unified-domain-models.md
@@ -1,0 +1,61 @@
+# Unified Domain Model Reference
+
+This document summarizes the core domain objects that make up the Unified Architecture translation pipeline. It follows the actual code structure closely so you can quickly understand the role and main API of each class when extending `TranslatorFactory`, parsers, or appliers.
+
+## TranslationInput
+
+- **Path**: [`src/react/unified/domain/translation-input.ts`](src/react/unified/domain/translation-input.ts)
+- **Shape**:
+
+  ```ts
+  export class TranslationInput<T = unknown> {
+    constructor(
+      public readonly content: string | File,
+      public readonly options: T,
+      public readonly aiConfig: AiTranslatorConfig,
+      public readonly promptPresetContent?: string
+    ) {}
+  }
+  ```
+
+- `content` accepts exactly one string or one `File`. Multi-file uploads are split into per-file jobs by [`TranslationJobManager`](src/react/services/job-manager/TranslationJobManager.ts), and each job receives its own `TranslationInput`.
+- `options` carries the parser DTO directly, including any custom fields that extend `BaseParseOptionsDto`.
+- `aiConfig` bundles translator settings such as provider, API key, and preset name. The `useTranslator` hook constructs it from the config store and user input.
+- `promptPresetContent` is an optional advanced prompt preset string passed through to the translator.
+
+## TranslationUnit
+
+- **Path**: [`src/react/unified/domain/translation-unit.ts`](src/react/unified/domain/translation-unit.ts)
+- **Purpose**: the minimal translatable unit produced by parsers, such as a sentence or subtitle line.
+- **Fields**:
+  - `key`: identifier used to map the translated result back into the original structure
+  - `source`: source text
+  - `target`: translated text, initially empty if needed
+
+## TranslationOutput
+
+- **Path**: [`src/react/unified/domain/translation-output.ts`](src/react/unified/domain/translation-output.ts)
+- **Key features**:
+  - stores multiple `TranslationResult` entries and merges pipeline results through `TranslationOutput.merge`
+  - returns all results or a single result through `getResults` and `getResult`
+  - summarizes success and failure by original file through `getAggregatedReport`
+  - generates download-ready blobs through `toZip` and `getSingleFile`
+
+## TranslationStrategy and TranslatorEngine
+
+- **Strategy interface**: [`src/react/unified/domain/translation-strategy.ts`](src/react/unified/domain/translation-strategy.ts)
+- **Engine implementation**: [`src/react/unified/engine/translator-engine.ts`](src/react/unified/engine/translator-engine.ts)
+- `TranslationStrategy` groups the parser, translator, and applier for a translation type.
+- `TranslatorEngine.translate` runs this order with a fixed progress callback contract:
+  1. `parser.parse(input)`
+  2. `translator.translate(units, aiConfig, promptPresetContent, sourceFilePath)`
+  3. `applier.apply(input, translatedUnits)`
+- For file input, the engine extracts `path` from the Electron `File` object and forwards it to the translator when a local-file-based translator needs it.
+
+## Integration with the Job Manager
+
+- **Path**: [`src/react/services/job-manager/TranslationJobManager.ts`](src/react/services/job-manager/TranslationJobManager.ts)
+- When users select multiple files, `useTranslator` queues each one as a separate `Job<File | string>`.
+- Parsers and appliers only need to handle a single input at a time; concurrency is handled by `TranslationJobManager`.
+- Job status follows `PENDING -> RUNNING -> (SUCCEEDED | FAILED | CANCELLED)`.
+- After every job completes, results are merged, reports are created, and ZIP or single-file downloads are prepared automatically.

--- a/docs/en/vllm-local-server.md
+++ b/docs/en/vllm-local-server.md
@@ -1,0 +1,86 @@
+# Local vLLM Server Guide (Qwen3-4B-Instruct-2507)
+
+## Overview
+
+This document summarizes the minimum setup required to run a vLLM server as an **OpenAI-compatible translator** for Formatted Docs AI Translator. The baseline model is `Qwen/Qwen3-4B-Instruct-2507`.
+
+## Requirements
+
+- NVIDIA GPU with CUDA drivers
+- Python 3.10 or newer
+- Enough disk space to download the model
+- A recent vLLM version so structured output support is available
+
+## Install vLLM
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install vllm
+```
+
+If installation fails because of CUDA or driver issues, start with the official vLLM documentation.
+
+## Start the Server
+
+```bash
+python -m vllm.entrypoints.openai.api_server \
+  --model Qwen/Qwen3-4B-Instruct-2507 \
+  --host 0.0.0.0 \
+  --port 8001 \
+  --max-model-len 8192 \
+  --gpu-memory-utilization 0.9
+```
+
+- Tune `--max-model-len` and `--gpu-memory-utilization` based on available VRAM.
+- If authentication is required, enable the matching vLLM API key option and use the same key in the client.
+
+## Verify the Server
+
+```bash
+curl http://localhost:8001/v1/models
+```
+
+If the server returns JSON, it is running correctly.
+
+## Connect the App (OpenAI-compatible mode)
+
+Use the following values in the app settings screen:
+
+- **Provider**: `OpenAI-compatible`
+- **Base URL**: `http://localhost:8001/v1`
+- **API Key**: the configured key if auth is enabled; otherwise any placeholder string
+- **Model Name**: `Qwen/Qwen3-4B-Instruct-2507`
+- **Max Concurrent Requests**: tune this to match the server and VRAM limits
+
+Store the configuration as a model preset if you want to reuse it quickly.
+
+## JSON Response Notes
+
+The app uses `response_format: json_schema` to force **structured JSON**. Support may differ across vLLM versions, so after upgrades it is worth validating with a request like this:
+
+```bash
+curl http://localhost:8001/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer local" \
+  -d '{
+    "model": "Qwen/Qwen3-4B-Instruct-2507",
+    "messages": [
+      { "role": "system", "content": "You are a translator. Return JSON only." },
+      { "role": "user", "content": "Translate to Korean: This is a test." }
+    ],
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": {
+        "name": "translation_result",
+        "schema": {
+          "type": "object",
+          "properties": { "text": { "type": "string" } },
+          "required": ["text"],
+          "additionalProperties": false
+        }
+      }
+    }
+  }'
+```

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -2,6 +2,8 @@
 
 이 문서는 Formatted Docs AI Translator의 아키텍처, 개발 프로세스, 그리고 기여 방법을 안내합니다.
 
+영문 문서는 [docs/en/index.md](../en/index.md)에서 확인할 수 있습니다.
+
 ## 시작하기
 
 -   **[릴리스 프로세스](./how-to-release.md)**: 새 버전의 소프트웨어를 릴리스하는 방법을 설명합니다.


### PR DESCRIPTION
## 변경 내용
- `README.md`는 영어 메인 유지, `README.ko.md`를 새로 추가해 한국어 README를 분리했습니다.
- `docs/en/index.md`를 실제 영어 문서 세트의 인덱스로 확장했습니다.
- `docs/ko`의 문서 구조에 맞춰 `docs/en`에 대응 문서를 추가했습니다.
  - `PACKAGING.md`
  - `how-to-release.md`
  - `frontend-architecture.md`
  - `job-management-system.md`
  - `unified-domain-models.md`
  - `adding-parser.md`
  - `adding-frontend.md`
  - `adding-image-translation.md`
  - `languages.md`
  - `rest-migration-plan.md`
  - `vllm-local-server.md`
- `docs/ko/index.md`에서 영문 문서 진입점을 함께 안내하도록 보강했습니다.

## 배경
- 이전 PR에서 README와 Codex 관련 표면만 영어 메인으로 정리했지만, 개발자 문서 전체는 여전히 한국어 중심이었습니다.
- 외부 OSS 리뷰어나 OpenAI 측에서 저장소를 읽을 때 영어 문서 세트가 직접 제공되는 편이 더 자연스럽다고 보고, 이번 브랜치에서 문서 구조를 1:1 대응으로 맞췄습니다.
- 동시에 기존 한국어 문서는 유지해 로컬 사용자와 기존 문서 흐름을 깨지 않도록 했습니다.

## 적용 기준
- 영어는 대외용 메인 표면
- 한국어는 별도 README와 `docs/ko`로 유지
- 문서 파일명과 구조는 `docs/ko`와 `docs/en`이 가능한 한 동일하게 유지

## 검증
- `yarn lint`
- `yarn test`
- `yarn build`
